### PR TITLE
Fix: File is not a picture (on Android 10 or above)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Security` in case of vulnerabilities.
 
 ## unreleased
+### Fixed
+- Uri for camera capture option is now invariant for Android 10 and above
 
 ## [2.0.0] - 06/01/21
 ### Changed

--- a/cropper/src/main/java/com/canhub/cropper/CropImage.java
+++ b/cropper/src/main/java/com/canhub/cropper/CropImage.java
@@ -344,7 +344,7 @@ public final class CropImage {
                 outputFileUri = FileProvider.getUriForFile(
                         context,
                         context.getPackageName() + CommonValues.authority,
-                        File.createTempFile("pickImageResult", ".jpeg", getImage)
+                        new File(getImage.getPath(), "pickImageResult.jpeg")
                 );
             } catch (Exception e) {
                 outputFileUri = Uri.fromFile(new File(getImage.getPath(), "pickImageResult.jpeg"));


### PR DESCRIPTION
* Fix getCaptureImageOutputUri(Context): Uri to return same file in each call on Android 10 or above.

close #21 

## Bug
### Cause:
On Android 10 or above there is a problem when ask Uri to dump camera image. The Uri passed to the camera intent via `MediaStore.EXTRA_OUTPUT` is different to the Uri when we are going to read the image. This is because the method was creating a temporary file in each call.

### Reproduce
Run project test module on any Android 10 or above and select camere to obtain the image.

### How the bug was solved:
The bug was solved changing the Uri returned when on Android 10 or above. Now, the Uri returned is build like Android 9 or lower. That is, the returned Uri is `new File(getImage.getPath(), "pickImageResult.jpeg")`
