### PR TITLE
prepare for 2.0.0 release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,10 @@ _very small explanation about what was done_
 _small explanation_
 
 ### Reproduce
+_more detail steps better_
+GIVEN:
+WHEN:
+THEN:
 
 ### How the bug was solved:
 Small explanation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## unreleased
-### Fixed
-- Uri for camera capture option is now invariant for Android 10 and above
+## [unreleased 2.x.x] -
 
-## [2.0.0] - 06/01/21
+## [2.0.0] - 12/01/21
 ### Changed
-- AsyncTask to Kotlin Coroutines
+- AsyncTask to Kotlin Coroutines [#9](https://github.com/CanHub/Android-Image-Cropper/issues/9)
+
+### Fixed
+- Uri for camera capture option is now invariant for Android 10 and above [#21](https://github.com/CanHub/Android-Image-Cropper/issues/21)
 
 ## [1.1.1] - 03/01/21
 ### Added


### PR DESCRIPTION
## Description:
New release `2.0.0`

### Changed
- AsyncTask to Kotlin Coroutines [#9](https://github.com/CanHub/Android-Image-Cropper/issues/9)

### Fixed
- Uri for camera capture option is now invariant for Android 10 and above [#21](https://github.com/CanHub/Android-Image-Cropper/issues/21)

## Backward compatibility:
With the new version user need to make Java 8 available

- Go to app level `build.gradle` file

- Add this line inside ```android``` in build.gradle
	```groovy
	compileOptions {
        sourceCompatibility JavaVersion.VERSION_1_8
        targetCompatibility JavaVersion.VERSION_1_8
    }
	```