### PR TITLE
fixed the bug that Gallery picker option is not showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Null CompressFormat [#44](https://github.com/CanHub/Android-Image-Cropper/issues/44)
+- [Galley option not showing](https://github.com/CanHub/Android-Image-Cropper/issues/20)
+- [Camera option not showing](https://github.com/CanHub/Android-Image-Cropper/issues/52)
 
 ## [2.0.3] - 27/01/21
 Versions `2.0.1` and `2.0.2` are similar, issues with jitpack.

--- a/cropper/src/main/AndroidManifest.xml
+++ b/cropper/src/main/AndroidManifest.xml
@@ -1,6 +1,19 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.canhub.cropper">
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.GET_CONTENT" />
+            <category android:name="android.intent.category.OPENABLE"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.PICK" />
+            <category android:name="android.intent.category.OPENABLE"/>
+        </intent>
+        <intent>
+            <action android:name="android.media.action.IMAGE_CAPTURE" />
+        </intent>
+    </queries>
     <application>
         <provider
             android:name=".CropFileProvider"

--- a/cropper/src/main/AndroidManifest.xml
+++ b/cropper/src/main/AndroidManifest.xml
@@ -7,10 +7,6 @@
             <category android:name="android.intent.category.OPENABLE"/>
         </intent>
         <intent>
-            <action android:name="android.intent.action.PICK" />
-            <category android:name="android.intent.category.OPENABLE"/>
-        </intent>
-        <intent>
             <action android:name="android.media.action.IMAGE_CAPTURE" />
         </intent>
     </queries>

--- a/cropper/src/main/AndroidManifest.xml
+++ b/cropper/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
         <intent>
             <action android:name="android.intent.action.GET_CONTENT" />
             <category android:name="android.intent.category.OPENABLE"/>
+            <data android:mimeType="*/*" />
         </intent>
         <intent>
             <action android:name="android.media.action.IMAGE_CAPTURE" />

--- a/cropper/src/main/java/com/canhub/cropper/CropImage.java
+++ b/cropper/src/main/java/com/canhub/cropper/CropImage.java
@@ -210,13 +210,7 @@ public final class CropImage {
             allIntents.addAll(getCameraIntents(context, packageManager));
         }
 
-        List<Intent> galleryIntents =
-                getGalleryIntents(packageManager, Intent.ACTION_GET_CONTENT, includeDocuments);
-        if (galleryIntents.size() == 0) {
-            // if no intents found for get-content try pick intent action (Huawei P9).
-            galleryIntents = getGalleryIntents(packageManager, Intent.ACTION_PICK, includeDocuments);
-        }
-        allIntents.addAll(galleryIntents);
+        allIntents.addAll(getGalleryIntents(packageManager, Intent.ACTION_GET_CONTENT, includeDocuments));
 
         Intent target;
         if (allIntents.isEmpty()) {
@@ -278,6 +272,11 @@ public final class CropImage {
             allIntents.add(intent);
         }
 
+        // Just in case queryIntentActivities returns emptyList
+        if (allIntents.isEmpty()) {
+            allIntents.add(captureIntent);
+        }
+
         return allIntents;
     }
 
@@ -289,11 +288,10 @@ public final class CropImage {
     public static List<Intent> getGalleryIntents(
             @NonNull PackageManager packageManager, String action, boolean includeDocuments) {
         List<Intent> intents = new ArrayList<>();
-        Intent galleryIntent =
-                action == Intent.ACTION_GET_CONTENT
-                        ? new Intent(action)
-                        : new Intent(action, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
-        galleryIntent.setType("image/*");
+        Intent galleryIntent = new Intent(action);
+        galleryIntent.setType(includeDocuments ? "*/*" : "image/*");
+        galleryIntent.addCategory(Intent.CATEGORY_OPENABLE);
+
         List<ResolveInfo> listGallery = packageManager.queryIntentActivities(galleryIntent, 0);
         for (ResolveInfo res : listGallery) {
             Intent intent = new Intent(galleryIntent);
@@ -314,6 +312,12 @@ public final class CropImage {
                 }
             }
         }
+
+        // Just in case queryIntentActivities returns emptyList
+        if (intents.isEmpty()) {
+            intents.add(galleryIntent);
+        }
+
         return intents;
     }
 

--- a/cropper/src/main/java/com/canhub/cropper/CropImage.java
+++ b/cropper/src/main/java/com/canhub/cropper/CropImage.java
@@ -154,7 +154,6 @@ public final class CropImage {
      *
      * @param activity the activity to be used to start activity from
      */
-    // TODO Issue #20
     public static void startPickImageActivity(@NonNull Activity activity) {
         activity.startActivityForResult(
                 getPickImageChooserIntent(activity), PICK_IMAGE_CHOOSER_REQUEST_CODE);
@@ -286,7 +285,7 @@ public final class CropImage {
         galleryIntent.addCategory(Intent.CATEGORY_OPENABLE);
 
         List<ResolveInfo> listGallery = packageManager.queryIntentActivities(galleryIntent, 0);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && listGallery.size() > 2) {
+        if (CommonVersionCheck.INSTANCE.isAtLeastQ29() && listGallery.size() > 2) {
             // Workaround for the bug that only 2 items are shown in Android Q
             // // https://issuetracker.google.com/issues/134367295
             // Trying to pick best match items

--- a/cropper/src/main/java/com/canhub/cropper/CropImage.java
+++ b/cropper/src/main/java/com/canhub/cropper/CropImage.java
@@ -210,7 +210,13 @@ public final class CropImage {
             allIntents.addAll(getCameraIntents(context, packageManager));
         }
 
-        allIntents.add(getGalleryIntent(Intent.ACTION_GET_CONTENT, includeDocuments));
+        List<Intent> galleryIntents =
+                getGalleryIntents(packageManager, Intent.ACTION_GET_CONTENT, includeDocuments);
+        if (galleryIntents.size() == 0) {
+            // if no intents found for get-content try pick intent action (Huawei P9).
+            galleryIntents = getGalleryIntents(packageManager, Intent.ACTION_PICK, includeDocuments);
+        }
+        allIntents.addAll(galleryIntents);
 
         Intent target;
         if (allIntents.isEmpty()) {
@@ -275,17 +281,40 @@ public final class CropImage {
         return allIntents;
     }
 
+
     /**
      * Get all Gallery intents for getting image from one of the apps of the device that handle
      * images.
      */
-    public static Intent getGalleryIntent(String action, boolean includeDocuments) {
-        Intent galleryIntent = new Intent();
-        galleryIntent.setAction(action);
-        galleryIntent.setType(includeDocuments ? "*/*" : "image/*");
-        galleryIntent.addCategory(Intent.CATEGORY_OPENABLE);
+    public static List<Intent> getGalleryIntents(
+            @NonNull PackageManager packageManager, String action, boolean includeDocuments) {
+        List<Intent> intents = new ArrayList<>();
+        Intent galleryIntent =
+                action == Intent.ACTION_GET_CONTENT
+                        ? new Intent(action)
+                        : new Intent(action, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
+        galleryIntent.setType("image/*");
+        List<ResolveInfo> listGallery = packageManager.queryIntentActivities(galleryIntent, 0);
+        for (ResolveInfo res : listGallery) {
+            Intent intent = new Intent(galleryIntent);
+            intent.setComponent(new ComponentName(res.activityInfo.packageName, res.activityInfo.name));
+            intent.setPackage(res.activityInfo.packageName);
+            intents.add(intent);
+        }
 
-        return galleryIntent;
+        // remove documents intent
+        if (!includeDocuments) {
+            for (Intent intent : intents) {
+                if (intent
+                        .getComponent()
+                        .getClassName()
+                        .equals("com.android.documentsui.DocumentsActivity")) {
+                    intents.remove(intent);
+                    break;
+                }
+            }
+        }
+        return intents;
     }
 
     /**

--- a/cropper/src/main/java/com/canhub/cropper/CropImageOptions.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageOptions.kt
@@ -433,7 +433,7 @@ open class CropImageOptions : Parcelable {
     }
 
     companion object {
-
+        @JvmField
         val CREATOR: Parcelable.Creator<CropImageOptions?> =
             object : Parcelable.Creator<CropImageOptions?> {
                 override fun createFromParcel(parcel: Parcel): CropImageOptions? {

--- a/sample/src/main/java/com/canhub/cropper/sample/crop_image_view/app/CropImageViewFragment.kt
+++ b/sample/src/main/java/com/canhub/cropper/sample/crop_image_view/app/CropImageViewFragment.kt
@@ -72,17 +72,16 @@ internal class CropImageViewFragment :
             OptionsDialogBottomSheet.show(childFragmentManager, options, this)
         }
 
-        // TODO Issue #20
-//        binding.searchImage.setOnClickListener {
-//            context?.let { ctx ->
-//                if (CropImage.isExplicitCameraPermissionRequired(ctx)) {
-//                    requestPermissions(
-//                        arrayOf(Manifest.permission.CAMERA),
-//                        CropImage.CAMERA_CAPTURE_PERMISSIONS_REQUEST_CODE
-//                    )
-//                } else activity?.let { CropImage.startPickImageActivity(it) }
-//            }
-//        }
+        binding.searchImage.setOnClickListener {
+            context?.let { ctx ->
+                if (CropImage.isExplicitCameraPermissionRequired(ctx)) {
+                    requestPermissions(
+                        arrayOf(Manifest.permission.CAMERA),
+                        CropImage.CAMERA_CAPTURE_PERMISSIONS_REQUEST_CODE
+                    )
+                } else activity?.let { CropImage.startPickImageActivity(it) }
+            }
+        }
 
         binding.reset.setOnClickListener {
             binding.cropImageView.apply {

--- a/sample/src/main/java/com/canhub/cropper/sample/crop_image_view/app/CropImageViewFragment.kt
+++ b/sample/src/main/java/com/canhub/cropper/sample/crop_image_view/app/CropImageViewFragment.kt
@@ -79,7 +79,7 @@ internal class CropImageViewFragment :
                         arrayOf(Manifest.permission.CAMERA),
                         CropImage.CAMERA_CAPTURE_PERMISSIONS_REQUEST_CODE
                     )
-                } else activity?.let { CropImage.startPickImageActivity(it) }
+                } else context?.let { context -> CropImage.startPickImageActivity(context, this) }
             }
         }
 
@@ -156,9 +156,12 @@ internal class CropImageViewFragment :
         binding.cropImageView.setOnCropImageCompleteListener(null)
     }
 
-    override fun onSetImageUriComplete(view: CropImageView, uri: Uri, error: Exception) {
-        Log.e("AIC", "Failed to load image by URI", error)
-        Toast.makeText(activity, "Image load failed: " + error.message, Toast.LENGTH_LONG).show()
+    override fun onSetImageUriComplete(view: CropImageView, uri: Uri, error: Exception?) {
+        if (error != null) {
+            Log.e("AIC", "Failed to load image by URI", error)
+            Toast.makeText(activity, "Image load failed: " + error.message, Toast.LENGTH_LONG)
+                .show()
+        }
     }
 
     override fun onCropImageComplete(view: CropImageView, result: CropResult) {

--- a/sample/src/main/res/layout/fragment_main.xml
+++ b/sample/src/main/res/layout/fragment_main.xml
@@ -45,17 +45,16 @@
         app:pressedTranslationZ="@dimen/elevation_fab_pressed"
         tools:ignore="ContentDescription" />
 
-<!--  Todo Issue #20  -->
-<!--    <com.google.android.material.floatingactionbutton.FloatingActionButton-->
-<!--        android:id="@+id/searchImage"-->
-<!--        android:layout_width="wrap_content"-->
-<!--        android:layout_height="wrap_content"-->
-<!--        android:layout_margin="@dimen/keyline_x4"-->
-<!--        android:elevation="@dimen/elevation_fab_resting_or_snackbar"-->
-<!--        android:src="@drawable/ic_mage_search_24"-->
-<!--        app:layout_constraintBottom_toBottomOf="parent"-->
-<!--        app:layout_constraintStart_toStartOf="parent"-->
-<!--        app:pressedTranslationZ="@dimen/elevation_fab_pressed"-->
-<!--        tools:ignore="ContentDescription" />-->
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/searchImage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/keyline_x4"
+        android:elevation="@dimen/elevation_fab_resting_or_snackbar"
+        android:src="@drawable/ic_mage_search_24"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:pressedTranslationZ="@dimen/elevation_fab_pressed"
+        tools:ignore="ContentDescription" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
close #20 #52

## Bug
### Cause:
Wrong Intent for gallery

### Reproduce
please refer #20 
```
val intent = CropImage.activity()
    .setCropShape(CropImageView.CropShape.RECTANGLE)
    .setAspectRatio(1, 1)
    .setFixAspectRatio(true)
    .setGuidelines(CropImageView.Guidelines.ON)
    .setCropMenuCropButtonTitle("OK")
    .getIntent(this)
startActivityForResult(intent, 123)
```

### How the bug was solved:
Copy [the code from legacy lib](https://github.com/ArthurHub/Android-Image-Cropper/blob/master/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImage.java#L192)
