### PR TITLE
Prepare for release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [unreleased 2.1.0] -
+## [unreleased 2.2.0] -
+
+
+## [2.1.0] - 11/02/21
 ### Changed
 - From Java to Kotlin: [CropImageOptions](https://github.com/CanHub/Android-Image-Cropper/issues/40), [CropWindowHandler](https://github.com/CanHub/Android-Image-Cropper/issues/37)
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,7 +1,7 @@
 ext {
 
     // Project
-    libVersion = "2.0.3"
+    libVersion = "2.1.0"
     compileSdkVersion = 30
     targetSdkVersion = 30
     minSdkVersion = 14


### PR DESCRIPTION
## 2.1.0
### Changed
- From Java to Kotlin: [CropImageOptions](https://github.com/CanHub/Android-Image-Cropper/issues/40), [CropWindowHandler](https://github.com/CanHub/Android-Image-Cropper/issues/37) Thanks @loukwn 

### Fixed
- Null CompressFormat [#44](https://github.com/CanHub/Android-Image-Cropper/issues/44) 
- [Galley option not showing](https://github.com/CanHub/Android-Image-Cropper/issues/20) Thanks @datdescartes 
- [Camera option not showing](https://github.com/CanHub/Android-Image-Cropper/issues/52) Thanks @datdescartes 