### PR TITLE
clear mRestoreCropWindowRect and mRestoreDegreesRotated when using setImageBitmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - CropImage.getActivityResult(data).getBitmap(context) [#49](https://github.com/CanHub/Android-Image-Cropper/issues/49)
 
+### Fixed
+- CropImageView incorrectly restored on rotation [#68](https://github.com/CanHub/Android-Image-Cropper/issues/68)
+
 ## [2.1.0] - 11/02/21
 ### Changed
 - From Java to Kotlin: [CropImageOptions](https://github.com/CanHub/Android-Image-Cropper/issues/40), [CropWindowHandler](https://github.com/CanHub/Android-Image-Cropper/issues/37)

--- a/cropper/src/main/java/com/canhub/cropper/CropImageView.java
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageView.java
@@ -1022,8 +1022,6 @@ public class CropImageView extends FrameLayout {
 
       // either no existing task is working or we canceled it, need to load new URI
       clearImageInt();
-      mRestoreCropWindowRect = null;
-      mRestoreDegreesRotated = 0;
       mCropOverlayView.setInitialCropWindowRect(null);
       mBitmapLoadingWorkerJob = new WeakReference<>(new BitmapLoadingWorkerJob((FragmentActivity)getContext(),this, uri));
       mBitmapLoadingWorkerJob.get().start();
@@ -1195,8 +1193,6 @@ public class CropImageView extends FrameLayout {
       mImageView.clearAnimation();
 
       clearImageInt();
-      mRestoreCropWindowRect = null;
-      mRestoreDegreesRotated = 0;
 
       mBitmap = bitmap;
       mImageView.setImageBitmap(mBitmap);
@@ -1238,6 +1234,8 @@ public class CropImageView extends FrameLayout {
     mZoomOffsetY = 0;
     mImageMatrix.reset();
     mSaveInstanceStateBitmapUri = null;
+    mRestoreCropWindowRect = null;
+    mRestoreDegreesRotated = 0;
 
     mImageView.setImageBitmap(null);
 

--- a/cropper/src/main/java/com/canhub/cropper/CropImageView.java
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageView.java
@@ -1195,6 +1195,8 @@ public class CropImageView extends FrameLayout {
       mImageView.clearAnimation();
 
       clearImageInt();
+      mRestoreCropWindowRect = null;
+      mRestoreDegreesRotated = 0;
 
       mBitmap = bitmap;
       mImageView.setImageBitmap(mBitmap);
@@ -1527,6 +1529,7 @@ public class CropImageView extends FrameLayout {
           if (mRestoreDegreesRotated != mInitialDegreesRotated) {
             mDegreesRotated = mRestoreDegreesRotated;
             applyImageMatrix(r - l, b - t, true, false);
+            mRestoreDegreesRotated = 0;
           }
           mImageMatrix.mapRect(mRestoreCropWindowRect);
           mCropOverlayView.setCropWindowRect(mRestoreCropWindowRect);


### PR DESCRIPTION
#68 
# Template 2 [Bug]
## Bug
### Cause:
mRestoreCropWindowRect and mRestoreDegreesRotated weren't being cleared in all cases where a new image was set. They lingered on and when an image is next added they overwrote the crop rect with an old state one, which may have been related to a totally different image with different dimensions.

### Reproduce
See linked issue

### How the bug was solved:
Clear out these member variables a) When setting a new image, and b) When they are used to restore state. (Some attempt at both of these points had already been made - just not enough.)
