### PR TITLE
Release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [unreleased 2.1.1] -
+## [unreleased x.x.x] -
 
+## [2.1.1] - 27/02/21
 ### Added
 - CropImage.getActivityResult(data).getBitmap(context) [#49](https://github.com/CanHub/Android-Image-Cropper/issues/49)
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,7 +1,7 @@
 ext {
 
     // Project
-    libVersion = "2.1.0"
+    libVersion = "2.1.1"
     compileSdkVersion = 30
     targetSdkVersion = 30
     minSdkVersion = 14


### PR DESCRIPTION
## [2.1.1] - 27/02/21
### Added
- CropImage.getActivityResult(data).getBitmap(context) [#49](https://github.com/CanHub/Android-Image-Cropper/issues/49)

### Fixed
- CropImageView incorrectly restored on rotation [#68](https://github.com/CanHub/Android-Image-Cropper/issues/68)
