### PR TITLE
values-tr/strings.xml turkish translation changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Security` in case of vulnerabilities.
 
 ## [unreleased x.x.x] -
+### Fixed
+-  Turkish Translations [#72](https://github.com/CanHub/Android-Image-Cropper/pull/72)
 
 ## [2.1.1] - 27/02/21
 ### Added

--- a/cropper/src/main/res/values-tr/strings.xml
+++ b/cropper/src/main/res/values-tr/strings.xml
@@ -3,8 +3,8 @@
     <string name="crop_image_activity_title"></string>
     <string name="ic_rotate_left_24">Saat yönünde döndür</string>
     <string name="ic_rotate_right_24">döndürmek</string>
-    <string name="crop_image_menu_crop">ekin</string>
-    <string name="ic_flip_24">fiske</string>
+    <string name="crop_image_menu_crop">Kırp</string>
+    <string name="ic_flip_24">çevir</string>
     <string name="ic_flip_24_horizontally">Yatay olarak çevir</string>
     <string name="ic_flip_24_vertically">Dikey olarak çevir</string>
     <string name="pick_image_intent_chooser_title">Kaynağı seçin</string>


### PR DESCRIPTION
I have changed 2 translations in values-tr/strings.xml.  They were not correct.
those are the correct ones.
<string name="crop_image_menu_crop">Kırp</string>
<string name="ic_flip_24">çevir</string>


