### PR TITLE
Release/2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Security` in case of vulnerabilities.
 
 ## [unreleased x.x.x] -
+## [2.3.0] - 30/03/21
 ### Changed
 - CropOverlayView to Kotlin [#38](https://github.com/CanHub/Android-Image-Cropper/issues/38)
 - CropImageView to Kotlin [#39](https://github.com/CanHub/Android-Image-Cropper/issues/39)

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,7 +1,7 @@
 ext {
 
     // Project
-    libVersion = "2.2.2"
+    libVersion = "2.3.0"
     compileSdkVersion = 30
     targetSdkVersion = 30
     minSdkVersion = 14


### PR DESCRIPTION
Not important release, but to keep all changes into Kotlin in a separate release.
And we can have a milestone of when the library become 100% Kotlin.

## [2.3.0] - 30/03/21
### Changed
- CropOverlayView to Kotlin [#38](https://github.com/CanHub/Android-Image-Cropper/issues/38)
- CropImageView to Kotlin [#39](https://github.com/CanHub/Android-Image-Cropper/issues/39)
- CropImage to Kotlin [#41](https://github.com/CanHub/Android-Image-Cropper/issues/41)
- BitmapUtils to Kotlin [#35](https://github.com/CanHub/Android-Image-Cropper/issues/35)