### PR TITLE
New Methods to split uri and file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [unreleased x.x.x] -
+## [unreleased 3.0.0] -
+### Removed
+- Methods `getUri`. // todo canato, refactor naming when done
+
+### Add
+- Methods `getFilePath` and `getUriContent`. // todo canato, refactor naming when done
+
+### Fixed
+- ENOENT (no such file or directory) [#99](https://github.com/CanHub/Android-Image-Cropper/issues/99)
+- `content://` instead of `file://` [#83](https://github.com/CanHub/Android-Image-Cropper/issues/83) [#84](https://github.com/CanHub/Android-Image-Cropper/issues/84) 
+
 ## [2.3.1] - 01/04/21
 ### Changed
-- Added "fun" for all Kotlin interfaces when possible [#102] https://github.com/CanHub/Android-Image-Cropper/issues/102
+- Added "fun" for all Kotlin interfaces when possible [#102](https://github.com/CanHub/Android-Image-Cropper/issues/102)
 
 ## [2.3.0] - 30/03/21
 ### Changed


### PR DESCRIPTION
close #99
fix #83
fix 84

## Description:
### [WIP]
Most of the usage of this library expect the `URI` to be a file path, what is not it main propose. 
Based on this was decided to split into two methods and **remove** the old method.

This will break the contract, making us release a new major version (`3.0.0`)

Should be a small a specific change so we will avoid to deprecate. 

Open for suggestions in how to do and naming. Please open a [discussion](https://github.com/CanHub/Android-Image-Cropper/discussions) for it.

For now, the possible names:
- `getUriFilePath`
- `getUriContent`

keeping the `uri` term in both names is done on propose so the users can easily find. 

## Check list for the Code Reviewer:
* [ ] CHANGELOG
* [ ] README
* [ ] Wiki
* [ ] Version Number
