### PR TITLE
Change URI methods - 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [unreleased 3.0.0] -
+## [unreleased x.x.x] -
+
+## [3.0.0] - 13/04/21
 ### Removed
 - Methods `getUri`.
 
@@ -20,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - ENOENT (no such file or directory) [#99](https://github.com/CanHub/Android-Image-Cropper/issues/99)
 - `content://` instead of `file://` [#83](https://github.com/CanHub/Android-Image-Cropper/issues/83) [#84](https://github.com/CanHub/Android-Image-Cropper/issues/84) 
 
-## [2.3.2] - 12/04/21
+## [2.3.2-alpha] - 12/04/21
 ### Added
 - @JvmStatic annotation in CropImage.activity() and fun activity(uri) [#108](https://github.com/CanHub/Android-Image-Cropper/issues/108)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased 3.0.0] -
 ### Removed
-- Methods `getUri`. // todo canato, refactor naming when done
+- Methods `getUri`.
 
 ### Add
-- Methods `getFilePath` and `getUriContent`. // todo canato, refactor naming when done
+- Methods `getFilePath` and `getUriContent`.
 
 ### Fixed
 - ENOENT (no such file or directory) [#99](https://github.com/CanHub/Android-Image-Cropper/issues/99)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [unreleased x.x.x] -
+## [unreleased 3.0.0] -
+### Removed
+- Methods `getUri`. // todo canato, refactor naming when done
+
+### Add
+- Methods `getFilePath` and `getUriContent`. // todo canato, refactor naming when done
+
+### Fixed
+- ENOENT (no such file or directory) [#99](https://github.com/CanHub/Android-Image-Cropper/issues/99)
+- `content://` instead of `file://` [#83](https://github.com/CanHub/Android-Image-Cropper/issues/83) [#84](https://github.com/CanHub/Android-Image-Cropper/issues/84) 
+
 ## [2.3.1] - 01/04/21
 ### Changed
-- Added "fun" for all Kotlin interfaces when possible [#102] https://github.com/CanHub/Android-Image-Cropper/issues/102
+- Added "fun" for all Kotlin interfaces when possible [#102](https://github.com/CanHub/Android-Image-Cropper/issues/102)
 
 ## [2.3.0] - 30/03/21
 ### Changed

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ Android Image Cropper
 Only need if you run on devices under OS10 (SDK 29)
 
  ```xml
- <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
- <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-                 android:maxSdkVersion="28" />
+<manifest>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+</manifest>
  ```
 
  #### Step 4. Add this line to your Proguard config file
@@ -82,43 +84,52 @@ You can check a sample code in this project `com.canhub.cropper.sample.extend_ac
    android:theme="@style/Base.Theme.AppCompat"/> <!-- optional (needed if default theme has no action bar) -->
  ```
 - Setup your `CropImageView` after call `super.onCreate(savedInstanceState)`
- ```java
- override fun onCreate(savedInstanceState: Bundle?) {
-  super.onCreate(savedInstanceState)
-  setCropImageView(binding.cropImageView)
- }
+ ```kotlin
+override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setCropImageView(binding.cropImageView)
+}
  ```
 
 ### Start the default Activity
 - Start `CropImageActivity` using builder pattern from your activity
- ```java
- // start picker to get image for cropping and then use the image in cropping activity
- CropImage.activity()
-   .setGuidelines(CropImageView.Guidelines.ON)
-   .start(this);
+ ```kotlin
+class MainActivity {
+    private fun startCrop() {
+        // start picker to get image for cropping and then use the image in cropping activity
+        CropImage
+            .activity()
+            .setGuidelines(CropImageView.Guidelines.ON)
+            .start(this)
 
- // start cropping activity for pre-acquired image saved on the device
- CropImage.activity(imageUri)
-  .start(this);
+        // start cropping activity for pre-acquired image saved on the device
+        CropImage
+            .activity(imageUri)
+            .start(this)
 
- // for fragment (DO NOT use `getActivity()`)
- CropImage.activity()
-   .start(getContext(), this);
+        // for fragment (DO NOT use `getActivity()`)
+        CropImage
+            .activity()
+            .start(requireContext(), this)
+    }
+}
  ```
 
 - Override `onActivityResult` method in your activity to get crop result
- ```java
- @Override
- public void onActivityResult(int requestCode, int resultCode, Intent data) {
-   if (requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE) {
-     CropImage.ActivityResult result = CropImage.getActivityResult(data);
-     if (resultCode == RESULT_OK) {
-       Uri resultUri = result.getUri();
-     } else if (resultCode == CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE) {
-       Exception error = result.getError();
+ ```kotlin
+class MainActivity {
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+         if (requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE) {
+             val result = CropImage.getActivityResult(data)
+             if (resultCode == Activity.RESULT_OK) {
+                 val resultUri: Uri? = result?.uriContent
+                 val resultFilePath: String? = result?.getFilePath(requireContext())
+             } else if (resultCode == CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE) {
+                 val error = result!!.error
+             }
+         }
      }
-   }
- }
+}
  ```
 
 ## Using View
@@ -126,7 +137,6 @@ You can check a sample code in this project `com.canhub.cropper.sample.extend_ac
  ```xml
  <!-- Image Cropper fill the remaining available height -->
  <com.canhub.cropper.CropImageView
-   xmlns:custom="http://schemas.android.com/apk/res-auto"
    android:id="@+id/cropImageView"
    android:layout_width="match_parent"
    android:layout_height="0dp"
@@ -134,18 +144,18 @@ You can check a sample code in this project `com.canhub.cropper.sample.extend_ac
  ```
 
 3. Set image to crop
- ```java
- cropImageView.setImageUriAsync(uri);
+ ```kotlin
+ cropImageView.setImageUriAsync(uri)
  // or (prefer using uri for performance and better user experience)
- cropImageView.setImageBitmap(bitmap);
+ cropImageView.setImageBitmap(bitmap)
  ```
 
 4. Get cropped image
- ```java
+ ```kotlin
  // subscribe to async event using cropImageView.setOnCropImageCompleteListener(listener)
- cropImageView.getCroppedImageAsync();
+ cropImageView.getCroppedImageAsync()
  // or
- Bitmap cropped = cropImageView.getCroppedImage();
+ val cropped: Bitmap = cropImageView.getCroppedImage()
  ```
 
 ## Features

--- a/cropper/src/main/java/com/canhub/cropper/BitmapLoadingWorkerJob.kt
+++ b/cropper/src/main/java/com/canhub/cropper/BitmapLoadingWorkerJob.kt
@@ -1,9 +1,11 @@
 package com.canhub.cropper
 
+import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
+import com.canhub.cropper.utils.getFilePathFromUri
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.isActive
@@ -71,12 +73,14 @@ class BitmapLoadingWorkerJob internal constructor(
         currentJob?.cancel()
     }
 
-    // region: Inner class: Result
     /** The result of BitmapLoadingWorkerJob async loading.  */
     companion object class Result {
 
-        /** The Android URI of the image to load  */
-        val uri: Uri
+        /**
+         * The Android URI of the image to load.
+         * NOT a file path, for it use [getFilePath]
+         */
+        val uriContent: Uri
 
         /** The loaded bitmap  */
         val bitmap: Bitmap?
@@ -90,8 +94,11 @@ class BitmapLoadingWorkerJob internal constructor(
         /** The error that occurred during async bitmap loading.  */
         val error: Exception?
 
+        /** The file path of the image to load */
+        fun getFilePath(context: Context): String = getFilePathFromUri(context, uriContent)
+
         internal constructor(uri: Uri, bitmap: Bitmap?, loadSampleSize: Int, degreesRotated: Int) {
-            this.uri = uri
+            uriContent = uri
             this.bitmap = bitmap
             this.loadSampleSize = loadSampleSize
             this.degreesRotated = degreesRotated
@@ -99,12 +106,11 @@ class BitmapLoadingWorkerJob internal constructor(
         }
 
         internal constructor(uri: Uri, error: Exception?) {
-            this.uri = uri
+            uriContent = uri
             bitmap = null
             loadSampleSize = 0
             degreesRotated = 0
             this.error = error
         }
     }
-    // endregion
 }

--- a/cropper/src/main/java/com/canhub/cropper/CropImageActivity.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageActivity.kt
@@ -283,7 +283,7 @@ open class CropImageActivity :
                             )
                             getUriForFile(applicationContext, file)
                         } catch (e: Exception) {
-                            Log.e("CropImageActivity", "${e.message}")
+                            Log.e("AIC", "${e.message}")
                             val file = File.createTempFile("cropped", ext, cacheDir)
                             getUriForFile(applicationContext, file)
                         }

--- a/cropper/src/main/java/com/canhub/cropper/CropImageActivity.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageActivity.kt
@@ -170,7 +170,7 @@ open class CropImageActivity :
         if (requestCode == CropImage.PICK_IMAGE_CHOOSER_REQUEST_CODE) {
             if (resultCode == RESULT_CANCELED) setResultCancel()
             if (resultCode == RESULT_OK) {
-                cropImageUri = CropImage.getPickImageResultUri(this, data)
+                cropImageUri = CropImage.getPickImageResultUriContent(this, data)
                 // For API >= 23 we need to check specifically that we have permissions to read external
                 // storage.
                 if (cropImageUri?.let {
@@ -227,7 +227,7 @@ open class CropImageActivity :
     }
 
     override fun onCropImageComplete(view: CropImageView, result: CropResult) {
-        setResult(result.uri, result.error, result.sampleSize)
+        setResult(result.uriContent, result.error, result.sampleSize)
     }
 
     /**

--- a/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
@@ -13,7 +13,6 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.provider.MediaStore
 import android.util.AttributeSet
-import android.util.Log
 import android.util.Pair
 import android.view.LayoutInflater
 import android.widget.FrameLayout
@@ -861,8 +860,6 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
         setProgressBarVisibility()
         if (result.error == null) {
             mInitialDegreesRotated = result.degreesRotated
-            Log.v("CanatoXXX", result.uriContent.toString())
-            Log.v("CanatoXXX", result.getFilePath(context))
             setBitmap(
                 result.bitmap,
                 0,
@@ -872,8 +869,6 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
             )
         }
         val listener = mOnSetImageUriCompleteListener
-        Log.v("CanatoXXX", result.uriContent.toString())
-        Log.v("CanatoXXX", result.getFilePath(context))
         listener?.onSetImageUriComplete(this, result.uriContent, result.error)
     }
 

--- a/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
@@ -13,6 +13,7 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.provider.MediaStore
 import android.util.AttributeSet
+import android.util.Log
 import android.util.Pair
 import android.view.LayoutInflater
 import android.widget.FrameLayout
@@ -21,6 +22,7 @@ import android.widget.ProgressBar
 import androidx.exifinterface.media.ExifInterface
 import androidx.fragment.app.FragmentActivity
 import com.canhub.cropper.CropOverlayView.CropWindowChangeListener
+import com.canhub.cropper.utils.getFilePathFromUri
 import java.lang.ref.WeakReference
 import java.util.UUID
 import kotlin.math.max
@@ -849,7 +851,7 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
     }
 
     /**
-     * On complete of the async bitmap loading by [.setImageUriAsync] set the result to the
+     * On complete of the async bitmap loading by [setImageUriAsync] set the result to the
      * widget if still relevant and call listener if set.
      *
      * @param result the result of bitmap loading
@@ -859,10 +861,20 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
         setProgressBarVisibility()
         if (result.error == null) {
             mInitialDegreesRotated = result.degreesRotated
-            setBitmap(result.bitmap, 0, result.uri, result.loadSampleSize, result.degreesRotated)
+            Log.v("CanatoXXX", result.uriContent.toString())
+            Log.v("CanatoXXX", result.getFilePath(context))
+            setBitmap(
+                result.bitmap,
+                0,
+                result.uriContent,
+                result.loadSampleSize,
+                result.degreesRotated
+            )
         }
         val listener = mOnSetImageUriCompleteListener
-        listener?.onSetImageUriComplete(this, result.uri, result.error)
+        Log.v("CanatoXXX", result.uriContent.toString())
+        Log.v("CanatoXXX", result.getFilePath(context))
+        listener?.onSetImageUriComplete(this, result.uriContent, result.error)
     }
 
     /**
@@ -1651,8 +1663,10 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
         /**
          * The Android uri of the saved cropped image result.<br></br>
          * Null if get cropped image was executed, no output requested or failure.
+         *
+         * This is NOT the file path, please use [getFilePath]
          */
-        val uri: Uri?,
+        val uriContent: Uri?,
         /** The error that failed the loading/cropping (null if successful)  */
         val error: Exception?,
         /** The 4 points of the cropping window in the source image  */
@@ -1702,11 +1716,18 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
          */
         fun getBitmap(context: Context): Bitmap? {
             return bitmap ?: try {
-                MediaStore.Images.Media.getBitmap(context.contentResolver, uri)
+                MediaStore.Images.Media.getBitmap(context.contentResolver, uriContent)
             } catch (e: Exception) {
                 null
             }
         }
+
+        /**
+         * The file path of the image to load
+         * Null if get cropped image was executed, no output requested or failure.
+         */
+        fun getFilePath(context: Context): String? =
+            uriContent?.let { getFilePathFromUri(context, it) }
     }
 
     companion object {

--- a/cropper/src/main/java/com/canhub/cropper/utils/GetFilePathFromUri.kt
+++ b/cropper/src/main/java/com/canhub/cropper/utils/GetFilePathFromUri.kt
@@ -1,0 +1,68 @@
+package com.canhub.cropper.utils
+
+import android.content.Context
+import android.net.Uri
+import android.webkit.MimeTypeMap
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * This class will create a temporary file in the cache if need.
+ *
+ * When the uri already have `file://` schema we don't need to create a new file.
+ * The temporary file will always override a previous one, saving memory.
+ * Using the cache memory(context.cacheDir) we guarantee to not leak memory
+ *
+ * @param context used to access Android APIs, like content resolve, it is your activity/fragment.
+ * @param uri the URI to load the image from.
+ *
+ * @return string value of the File path.
+ */
+internal fun getFilePathFromUri(context: Context, uri: Uri): String  =
+    if (uri.path?.contains("file://") == true) uri.path!!
+    else getFileFromContentUri(context, uri).path
+
+private fun getFileFromContentUri(context: Context, contentUri: Uri): File {
+    // Preparing Temp file name
+    val fileExtension = getFileExtension(context, contentUri)
+    val fileName = "temp_file" + if (fileExtension != null) ".$fileExtension" else ""
+    // Creating Temp file
+    val tempFile = File(context.cacheDir, fileName)
+    tempFile.createNewFile()
+    //Initialize streams
+    var oStream: FileOutputStream? = null
+    var inputStream: InputStream? = null
+
+    try {
+        oStream = FileOutputStream(tempFile)
+        inputStream = context.contentResolver.openInputStream(contentUri)
+
+        inputStream?.let { copy(inputStream, oStream) }
+        oStream.flush()
+    } catch (e: Exception) {
+        e.printStackTrace()
+    } finally {
+        //Close streams
+        inputStream?.close()
+        oStream?.close()
+    }
+
+    return tempFile
+}
+
+private fun getFileExtension(context: Context, uri: Uri): String? {
+    val fileType: String? = context.contentResolver.getType(uri)
+    return MimeTypeMap.getSingleton().getExtensionFromMimeType(fileType)
+}
+
+@Throws(IOException::class)
+private fun copy(source: InputStream, target: OutputStream) {
+    val buf = ByteArray(8192)
+    var length: Int
+    while (source.read(buf).also { length = it } > 0) {
+        target.write(buf, 0, length)
+    }
+}

--- a/cropper/src/main/java/com/canhub/cropper/utils/GetFilePathFromUri.kt
+++ b/cropper/src/main/java/com/canhub/cropper/utils/GetFilePathFromUri.kt
@@ -21,7 +21,7 @@ import java.io.OutputStream
  *
  * @return string value of the File path.
  */
-internal fun getFilePathFromUri(context: Context, uri: Uri): String  =
+internal fun getFilePathFromUri(context: Context, uri: Uri): String =
     if (uri.path?.contains("file://") == true) uri.path!!
     else getFileFromContentUri(context, uri).path
 
@@ -32,7 +32,7 @@ private fun getFileFromContentUri(context: Context, contentUri: Uri): File {
     // Creating Temp file
     val tempFile = File(context.cacheDir, fileName)
     tempFile.createNewFile()
-    //Initialize streams
+    // Initialize streams
     var oStream: FileOutputStream? = null
     var inputStream: InputStream? = null
 
@@ -45,7 +45,7 @@ private fun getFileFromContentUri(context: Context, contentUri: Uri): File {
     } catch (e: Exception) {
         e.printStackTrace()
     } finally {
-        //Close streams
+        // Close streams
         inputStream?.close()
         oStream?.close()
     }

--- a/cropper/src/main/java/com/canhub/cropper/utils/GetUriForFile.kt
+++ b/cropper/src/main/java/com/canhub/cropper/utils/GetUriForFile.kt
@@ -30,13 +30,13 @@ import java.nio.file.Paths
 internal fun getUriForFile(context: Context, file: File): Uri {
     val authority = context.packageName + CommonValues.authority
     try {
-        Log.i("CropLibGetUri", "Try get URI for scope storage - content://")
+        Log.i("AIC", "Try get URI for scope storage - content://")
         return FileProvider.getUriForFile(context, authority, file)
     } catch (e: Exception) {
         try {
-            Log.e("CropLibGetUri", "${e.message}")
+            Log.e("AIC", "${e.message}")
             Log.w(
-                "CropLibGetUri",
+                "AIC",
                 "ANR Risk -- Copying the file the location cache to avoid 'external-files-path' bug for N+ devices"
             )
             // Note: Periodically clear this cache
@@ -49,13 +49,13 @@ internal fun getUriForFile(context: Context, file: File): Uri {
                 output = FileOutputStream(cacheLocation) // appending output stream
                 input.copyTo(output)
                 Log.i(
-                    "CropLibGetUri",
+                    "AIC",
                     "Completed Android N+ file copy. Attempting to return the cached file"
                 )
                 return FileProvider.getUriForFile(context, authority, cacheLocation)
             } catch (e: Exception) {
-                Log.e("CropLibGetUri", "${e.message}")
-                Log.i("CropLibGetUri", "Trying to provide URI manually")
+                Log.e("AIC", "${e.message}")
+                Log.i("AIC", "Trying to provide URI manually")
                 val path = "content://$authority/files/my_images/"
 
                 if (CommonVersionCheck.isAtLeastO26()) {
@@ -71,24 +71,24 @@ internal fun getUriForFile(context: Context, file: File): Uri {
                 output?.close()
             }
         } catch (e: Exception) {
-            Log.e("CropLibGetUri", "${e.message}")
+            Log.e("AIC", "${e.message}")
 
             if (!CommonVersionCheck.isAtLeastQ29()) {
                 val cacheDir = context.externalCacheDir
                 cacheDir?.let {
                     try {
                         Log.i(
-                            "CropLibGetUri",
+                            "AIC",
                             "Use External storage, do not work for OS 29 and above"
                         )
                         return Uri.fromFile(File(cacheDir.path, file.absolutePath))
                     } catch (e: Exception) {
-                        Log.e("CropLibGetUri", "${e.message}")
+                        Log.e("AIC", "${e.message}")
                     }
                 }
             }
             // If nothing else work we try
-            Log.i("CropLibGetUri", "Try get URI using file://")
+            Log.i("AIC", "Try get URI using file://")
             return Uri.fromFile(file)
         }
     }

--- a/sample/src/main/java/com/canhub/cropper/sample/camera/app/SCameraFragment.kt
+++ b/sample/src/main/java/com/canhub/cropper/sample/camera/app/SCameraFragment.kt
@@ -1,6 +1,7 @@
 package com.canhub.cropper.sample.camera.app
 
 import android.Manifest
+import android.app.Activity
 import android.app.AlertDialog
 import android.content.Intent
 import android.graphics.Bitmap
@@ -255,4 +256,7 @@ internal class SCameraFragment :
             storageDir
         )
     }
+
+
 }
+

--- a/sample/src/main/java/com/canhub/cropper/sample/camera/app/SCameraFragment.kt
+++ b/sample/src/main/java/com/canhub/cropper/sample/camera/app/SCameraFragment.kt
@@ -1,7 +1,6 @@
 package com.canhub.cropper.sample.camera.app
 
 import android.Manifest
-import android.app.Activity
 import android.app.AlertDialog
 import android.content.Intent
 import android.graphics.Bitmap
@@ -256,7 +255,4 @@ internal class SCameraFragment :
             storageDir
         )
     }
-
-
 }
-

--- a/sample/src/main/java/com/canhub/cropper/sample/camera/presenter/SCameraPresenter.kt
+++ b/sample/src/main/java/com/canhub/cropper/sample/camera/presenter/SCameraPresenter.kt
@@ -6,6 +6,7 @@ import android.app.Activity.RESULT_OK
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.util.Log
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
@@ -96,22 +97,31 @@ internal class SCameraPresenter : SCameraContract.Presenter {
             when (requestCode) {
                 CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE -> {
                     val bitmap = context?.let { CropImage.getActivityResult(data)?.getBitmap(it) }
-                    CropImage.getActivityResult(data)?.uri?.let {
+                    Log.v("File Path",
+                        context
+                            ?.let { CropImage.getActivityResult(data)?.getFilePath(it) }
+                            .toString()
+                    )
+
+                    CropImage.getActivityResult(data)?.uriContent?.let {
                         view?.handleCropImageResult(it.toString().replace("file:", ""))
                     } ?: view?.showErrorMessage("CropImage getActivityResult return null")
                 }
                 SCameraFragment.CUSTOM_REQUEST_CODE -> {
                     context?.let {
-                        val uri = CropImage.getPickImageResultUri(it, data)
+                        Log.v("File Path", CropImage.getPickImageResultFilePath(it, data))
+
+                        CropImage.getPickImageResultFilePath(it, data)
+                        val uri = CropImage.getPickImageResultUriContent(it, data)
                         view?.handleCropImageResult(uri.toString().replace("file:", ""))
                     }
                 }
                 CropImage.PICK_IMAGE_CHOOSER_REQUEST_CODE -> {
                     context?.let { ctx ->
-                        val uri = CropImage.getPickImageResultUri(ctx, data)
+                        Log.v("File Path", CropImage.getPickImageResultFilePath(ctx, data))
+                        val uri = CropImage.getPickImageResultUriContent(ctx, data)
 
-                        if (uri != null) view?.handleCropImageResult(uri.toString())
-                        else view?.showErrorMessage("Pick Image, null URI")
+                        view?.handleCropImageResult(uri.toString())
                     }
                 }
                 CODE_PHOTO_CAMERA -> view?.startCropImage(CameraEnumDomain.START_WITH_URI)

--- a/sample/src/main/java/com/canhub/cropper/sample/camera/presenter/SCameraPresenter.kt
+++ b/sample/src/main/java/com/canhub/cropper/sample/camera/presenter/SCameraPresenter.kt
@@ -6,11 +6,13 @@ import android.app.Activity.RESULT_OK
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.util.Log
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import com.canhub.cropper.CropImage
+import com.canhub.cropper.CropImage.getActivityResult
 import com.canhub.cropper.sample.camera.app.SCameraFragment
 import com.canhub.cropper.sample.camera.app.SCameraFragment.Companion.CODE_PHOTO_CAMERA
 import com.canhub.cropper.sample.camera.domain.CameraEnumDomain

--- a/sample/src/main/java/com/canhub/cropper/sample/camera/presenter/SCameraPresenter.kt
+++ b/sample/src/main/java/com/canhub/cropper/sample/camera/presenter/SCameraPresenter.kt
@@ -6,13 +6,11 @@ import android.app.Activity.RESULT_OK
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.net.Uri
 import android.util.Log
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import com.canhub.cropper.CropImage
-import com.canhub.cropper.CropImage.getActivityResult
 import com.canhub.cropper.sample.camera.app.SCameraFragment
 import com.canhub.cropper.sample.camera.app.SCameraFragment.Companion.CODE_PHOTO_CAMERA
 import com.canhub.cropper.sample.camera.domain.CameraEnumDomain
@@ -99,7 +97,8 @@ internal class SCameraPresenter : SCameraContract.Presenter {
             when (requestCode) {
                 CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE -> {
                     val bitmap = context?.let { CropImage.getActivityResult(data)?.getBitmap(it) }
-                    Log.v("File Path",
+                    Log.v(
+                        "File Path",
                         context
                             ?.let { CropImage.getActivityResult(data)?.getFilePath(it) }
                             .toString()

--- a/sample/src/main/java/com/canhub/cropper/sample/crop_image_view/app/SCropImageViewFragment.kt
+++ b/sample/src/main/java/com/canhub/cropper/sample/crop_image_view/app/SCropImageViewFragment.kt
@@ -177,7 +177,8 @@ internal class SCropImageViewFragment :
                     handleCropResult(CropImage.getActivityResult(data))
                 CropImage.PICK_IMAGE_CHOOSER_REQUEST_CODE -> {
                     val ctx = context
-                    val imageUri = ctx?.let { CropImage.getPickImageResultUri(it, data) }
+                    ctx?.let { Log.v("File Path", CropImage.getPickImageResultFilePath(it, data)) }
+                    val imageUri = ctx?.let { CropImage.getPickImageResultUriContent(it, data) }
 
                     if (imageUri != null &&
                         CropImage.isReadExternalStoragePermissionsRequired(ctx, imageUri)
@@ -229,8 +230,8 @@ internal class SCropImageViewFragment :
                 if (binding.cropImageView.cropShape == CropImageView.CropShape.OVAL)
                     result.bitmap?.let { CropImage.toOvalBitmap(it) }
                 else result.bitmap
-
-            SCropResultActivity.start(this, imageBitmap, result.uri, result.sampleSize)
+            context?.let { Log.v("File Path", result.getFilePath(it).toString()) }
+            SCropResultActivity.start(this, imageBitmap, result.uriContent, result.sampleSize)
         } else {
             Log.e("AIC", "Failed to crop image", result?.error)
             Toast

--- a/sample/src/main/java/com/canhub/cropper/sample/extend_activity/app/SExtendActivity.kt
+++ b/sample/src/main/java/com/canhub/cropper/sample/extend_activity/app/SExtendActivity.kt
@@ -94,7 +94,8 @@ internal class SExtendActivity : CropImageActivity(), SExtendContract.View {
             sampleSize
         )
 
-        binding.cropImageView.setImageUriAsync(result.uri)
+        Log.v("File Path", result.getFilePath(this).toString())
+        binding.cropImageView.setImageUriAsync(result.uriContent)
     }
 
     override fun setResultCancel() {
@@ -103,7 +104,10 @@ internal class SExtendActivity : CropImageActivity(), SExtendContract.View {
     }
 
     override fun updateMenuItemIconColor(menu: Menu, itemId: Int, color: Int) {
-        Log.i("extend", "If not using your layout, this can be one option to change colours. Check README and wiki for more")
+        Log.i(
+            "extend",
+            "If not using your layout, this can be one option to change colours. Check README and wiki for more"
+        )
         super.updateMenuItemIconColor(menu, itemId, color)
     }
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,7 +1,7 @@
 ext {
 
     // Project
-    libVersion = "2.3.1"
+    libVersion = "3.0.0"
     compileSdkVersion = 30
     targetSdkVersion = 30
     minSdkVersion = 14


### PR DESCRIPTION
close #99
fix #83
fix #84

## Description:
Most of the usage of this library expect the `URI` to be a file path, what is not it main propose. 
Based on this was decided to split into two methods and **remove** the old method.

This will break the contract, making us release a new major version (`3.0.0`)

Should be a small a specific change so we will avoid to deprecate. 

Open for suggestions in how to do and naming. Please open a [discussion](https://github.com/CanHub/Android-Image-Cropper/discussions) for it.

For now, the possible names:
- `getUriFilePath`
- `getUriContent`

keeping the `uri` term in both names is done on propose so the users can easily find. 

## Check list for the Code Reviewer:
* [x] CHANGELOG
* [x] README
* [x] Wiki
* [x] Version Number
