### PR TITLE
Static fun java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Security` in case of vulnerabilities.
 
 ## [unreleased x.x.x] -
+
+## [2.3.2] - 12/04/21
+### Added
+- @JvmStatic annotation in CropImage.activity() and fun activity(uri) [#108](https://github.com/CanHub/Android-Image-Cropper/issues/108)
+
 ## [2.3.1] - 01/04/21
 ### Changed
 - Added "fun" for all Kotlin interfaces when possible [#102] https://github.com/CanHub/Android-Image-Cropper/issues/102

--- a/cropper/src/main/java/com/canhub/cropper/CropImage.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImage.kt
@@ -426,6 +426,7 @@ object CropImage {
      *
      * @return builder for Crop Image Activity
      */
+    @JvmStatic
     fun activity(): ActivityBuilder {
         return ActivityBuilder(null)
     }
@@ -439,6 +440,7 @@ object CropImage {
      * @param uri the image Android uri source to crop or null to start a picker
      * @return builder for Crop Image Activity
      */
+    @JvmStatic
     fun activity(uri: Uri?): ActivityBuilder {
         return ActivityBuilder(uri)
     }


### PR DESCRIPTION
close #108 

## Not able to access CropImage.activity() function in Java class
### Cause:
_Not added @JvmStatic annotation in activity() function in CropImage_

### How the bug was solved:
Added @JvmStatic in fun activity() and fun activity(uri)
