### PR TITLE
[129] Make isReadExternalStoragePermissionsRequired visible in Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Security` in case of vulnerabilities.
 
 ## [unreleased x.x.x] -
+### Fixed
+- Cannot call library method from Java language [#129](https://github.com/CanHub/Android-Image-Cropper/issues/129)
 
 ## [3.1.0] - 09/05/21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased x.x.x] -
 ### Fixed
-- Cannot call library method from Java language [#129](https://github.com/CanHub/Android-Image-Cropper/issues/129)
+- Make isReadExternalStoragePermissionsRequired and 2 other functions visible in Java [#129](https://github.com/CanHub/Android-Image-Cropper/issues/129)
 
 ## [3.1.0] - 09/05/21
 ### Added

--- a/cropper/src/main/java/com/canhub/cropper/CropImage.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImage.kt
@@ -157,6 +157,7 @@ object CropImage {
      * @param context used to access Android APIs, like content resolve, it is your
      * activity/fragment/widget.
      */
+    @JvmStatic
     fun getPickImageChooserIntent(context: Context): Intent {
         return getPickImageChooserIntent(
             context = context,
@@ -177,6 +178,7 @@ object CropImage {
      * @param includeDocuments if to include KitKat documents activity containing all sources
      * @param includeCamera    if to include camera intents
      */
+    @JvmStatic
     fun getPickImageChooserIntent(
         context: Context,
         title: CharSequence?,
@@ -427,6 +429,7 @@ object CropImage {
      * @return true - required permission are not granted, false - either no need for permissions or
      * they are granted
      */
+    @JvmStatic
     fun isReadExternalStoragePermissionsRequired(
         context: Context,
         uri: Uri,

--- a/sample/src/main/java/com/canhub/cropper/sample/camera_java/app/SCameraFragmentJava.java
+++ b/sample/src/main/java/com/canhub/cropper/sample/camera_java/app/SCameraFragmentJava.java
@@ -109,10 +109,8 @@ public class SCameraFragmentJava extends Fragment implements SCameraContractJava
 
     private void startForResult() {
         assert (getContext() != null);
-        Intent intent = new Intent();
-        intent.setType("image/*");
-        intent.setAction(Intent.ACTION_GET_CONTENT);
-        startActivityForResult(Intent.createChooser(intent, "Select Picture"), CUSTOM_REQUEST_CODE);
+        Intent intent =  CropImage.getPickImageChooserIntent(getContext(),"Selection Baby", true, false);
+        startActivityForResult(intent, CUSTOM_REQUEST_CODE);
 
     }
 

--- a/sample/src/main/java/com/canhub/cropper/sample/camera_java/presenter/SCameraPresenterJava.java
+++ b/sample/src/main/java/com/canhub/cropper/sample/camera_java/presenter/SCameraPresenterJava.java
@@ -127,7 +127,7 @@ public class SCameraPresenterJava implements SCameraContractJava.Presenter {
                     );
 
                     Uri uriContent = CropImage.getActivityResult(data).getUriContent();
-                    if (uriContent != null) {
+                    if (uriContent != null && !CropImage.isReadExternalStoragePermissionsRequired(context, uriContent)) {
                         view.handleCropImageResult(uriContent.toString().replace("file:", ""));
                     } else {
                         view.showErrorMessage("CropImage getActivityResult return null");


### PR DESCRIPTION
_Add the issue linked to this PR_
close #129 - https://github.com/CanHub/Android-Image-Cropper/issues/129

# Template 2 [Bug]
## Bug - functions not available in Java
### Cause:
Missing JvmStatic annotation

### Reproduce
In java, the following code does not compile: if (CropImage.isReadExternalStoragePermissionsRequired(getContext(), imageUri))

### How the bug was solved:
Added missing annotation
