### PR TITLE
Library crashing issue resolved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ build/
 
 
 .idea/inspectionProfiles/
+
+.idea/runConfigurations.xml
+.idea/markdown-navigator.xml
+.idea/markdown-navigator-enh.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Security` in case of vulnerabilities.
 
 ## [unreleased x.x.x] -
+### Fixed
+- Crashing when using the code `CropImage.activity().start(requireActivity(), this)` resolved
 
 ## [3.1.1] - 17/05/21
 ### Fixed

--- a/cropper/src/main/AndroidManifest.xml
+++ b/cropper/src/main/AndroidManifest.xml
@@ -21,5 +21,6 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/library_file_paths" />
         </provider>
+        <activity android:name=".CropImageActivity" />
     </application>
 </manifest>


### PR DESCRIPTION
## Bug

### Cause:
The application using our library through gradle implementation will crash when using CropImage

### Reproduce
Use the below code:
`CropImage.activity().start(requireActivity(), this)`

### How the bug was solved:
Had to declare an activity in manifest file
