### PR TITLE
[BUG] - Missing file extension under Android 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased x.x.x] -
 ### Fixed
-- Crashing when using the code `CropImage.activity().start(requireActivity(), this)` resolved
+- Missing file extension under Android 10 [#138](https://github.com/CanHub/Android-Image-Cropper/issues/138)
+- Crashing when using the code `CropImage.activity().start(requireActivity(), this)` resolved [#133](https://github.com/CanHub/Android-Image-Cropper/issues/133)
 
 ## [3.1.1] - 17/05/21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Security` in case of vulnerabilities.
 
 ## [unreleased x.x.x] -
+
+## [3.1.2] - 07/06/21
 ### Fixed
 - Missing file extension under Android 10 [#138](https://github.com/CanHub/Android-Image-Cropper/issues/138)
 - Crashing when using the code `CropImage.activity().start(requireActivity(), this)` resolved [#133](https://github.com/CanHub/Android-Image-Cropper/issues/133)

--- a/cropper/src/main/java/com/canhub/cropper/utils/GetFilePathFromUri.kt
+++ b/cropper/src/main/java/com/canhub/cropper/utils/GetFilePathFromUri.kt
@@ -1,5 +1,6 @@
 package com.canhub.cropper.utils
 
+import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
 import android.webkit.MimeTypeMap
@@ -32,7 +33,7 @@ internal fun getFilePathFromUri(context: Context, uri: Uri, uniqueName: Boolean)
 
 private fun getFileFromContentUri(context: Context, contentUri: Uri, uniqueName: Boolean): File {
     // Preparing Temp file name
-    val fileExtension = getFileExtension(context, contentUri)
+    val fileExtension = getFileExtension(context, contentUri) ?: ""
     val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", getDefault()).format(Date())
     val fileName = ("temp_file_" + if (uniqueName) timeStamp else "") + ".$fileExtension"
     // Creating Temp file
@@ -59,10 +60,10 @@ private fun getFileFromContentUri(context: Context, contentUri: Uri, uniqueName:
     return tempFile
 }
 
-private fun getFileExtension(context: Context, uri: Uri): String {
-    val fileType: String? = context.contentResolver.getType(uri)
-    return MimeTypeMap.getSingleton().getExtensionFromMimeType(fileType) ?: ""
-}
+private fun getFileExtension(context: Context, uri: Uri): String? =
+    if (uri.scheme == ContentResolver.SCHEME_CONTENT)
+        MimeTypeMap.getSingleton().getExtensionFromMimeType(context.contentResolver.getType(uri))
+    else uri.path?.let { MimeTypeMap.getFileExtensionFromUrl(Uri.fromFile(File(it)).toString()) }
 
 @Throws(IOException::class)
 private fun copy(source: InputStream, target: OutputStream) {

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,7 +1,7 @@
 ext {
 
     // Project
-    libVersion = "3.1.1"
+    libVersion = "3.1.2"
     compileSdkVersion = 30
     targetSdkVersion = 30
     minSdkVersion = 14


### PR DESCRIPTION
close #138

## Bug
### Cause:
When the `uri` schema was file and not content the `contentResolver.getType()` doesn't work, like we can check in the documentation:  
> @param url A Uri identifying content (either a list or specific type), using the content:// scheme.

### Reproduce
GIVEN: Version 3.1.1 of the library, using `CropImage.activity()...start()` method
WHEN: Crop the image and request `CropImage.getActivityResult(data)?.getUriFilePath(it)` on ActivityResult
THEN: File path miss extension `file.` and not `file.jpeg` 

### How the bug was solved:
Add condition checking the schema and using the method `MimeTypeMap.getFileExtensionFromUrl` from the `uri` 
