### PR TITLE
Get FragmentActivity from ContextWrapper

### DIFF
--- a/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
@@ -19,9 +19,9 @@ import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.ProgressBar
 import androidx.exifinterface.media.ExifInterface
-import androidx.fragment.app.FragmentActivity
 import com.canhub.cropper.CropOverlayView.CropWindowChangeListener
 import com.canhub.cropper.utils.getFilePathFromUri
+import com.canhub.cropper.utils.getFragmentActivityFrom
 import java.lang.ref.WeakReference
 import java.util.UUID
 import kotlin.math.max
@@ -731,7 +731,7 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
             clearImageInt()
             mCropOverlayView!!.initialCropWindowRect = null
             mBitmapLoadingWorkerJob =
-                WeakReference(BitmapLoadingWorkerJob((context as FragmentActivity), this, uri))
+                WeakReference(BitmapLoadingWorkerJob(getFragmentActivityFrom(context), this, uri))
             mBitmapLoadingWorkerJob!!.get()!!.start()
             setProgressBarVisibility()
         }
@@ -999,7 +999,7 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
             ) {
                 WeakReference(
                     BitmapCroppingWorkerJob(
-                        (context as FragmentActivity),
+                        getFragmentActivityFrom(context),
                         this,
                         imageUri,
                         cropPoints,
@@ -1022,7 +1022,7 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
             } else {
                 WeakReference(
                     BitmapCroppingWorkerJob(
-                        (context as FragmentActivity),
+                        getFragmentActivityFrom(context),
                         this,
                         bitmap,
                         cropPoints,

--- a/cropper/src/main/java/com/canhub/cropper/utils/GetFragmentActivityFromContext.kt
+++ b/cropper/src/main/java/com/canhub/cropper/utils/GetFragmentActivityFromContext.kt
@@ -1,0 +1,14 @@
+package com.canhub.cropper.utils
+
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.fragment.app.FragmentActivity
+
+internal fun getFragmentActivityFrom(context: Context): FragmentActivity {
+    var unpackContext = context
+    while (unpackContext !is FragmentActivity && unpackContext is ContextWrapper) {
+        unpackContext = unpackContext.baseContext
+    }
+
+    return unpackContext as FragmentActivity
+}


### PR DESCRIPTION
close #136

## Bug
### Cause:
`android.view.ContextThemeWrapper cannot be cast to androidx.fragment.app.FragmentActivity`

### Reproduce
GIVEN: Version 3.1.1 of the library, view have attibute `android:theme`
WHEN: using `CropImageView.setImageUriAsync()` method
THEN: method try to cast `ContextThemeWrapper` to `FragmentActivity`

### How the bug was solved:
get `baseContext` from context as long as it not `FragmentActivity` and as long as it is `ContextWrapper`
