### PR TITLE
136 fix get fragmentactivity from contextwrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased x.x.x] -
 
+## [3.1.3] - 10/06/21
+### Fixed
+- ContextWrapper cannot be cast to FragmentActivity [#136](https://github.com/CanHub/Android-Image-Cropper/issues/136)
+
 ## [3.1.2] - 07/06/21
 ### Fixed
 - Missing file extension under Android 10 [#138](https://github.com/CanHub/Android-Image-Cropper/issues/138)

--- a/cropper/src/main/java/com/canhub/cropper/BitmapCroppingWorkerJob.kt
+++ b/cropper/src/main/java/com/canhub/cropper/BitmapCroppingWorkerJob.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.withContext
 import java.lang.ref.WeakReference
 import kotlin.coroutines.CoroutineContext
 
-class BitmapCroppingWorkerJob (
+class BitmapCroppingWorkerJob(
     private val context: Context,
     private val cropImageViewReference: WeakReference<CropImageView>,
     val uri: Uri?,

--- a/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
@@ -19,7 +19,6 @@ import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.ProgressBar
 import androidx.exifinterface.media.ExifInterface
-import androidx.fragment.app.FragmentActivity
 import com.canhub.cropper.CropOverlayView.CropWindowChangeListener
 import com.canhub.cropper.utils.getFilePathFromUri
 import java.lang.ref.WeakReference
@@ -731,7 +730,7 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
             clearImageInt()
             mCropOverlayView!!.initialCropWindowRect = null
             mBitmapLoadingWorkerJob =
-                WeakReference(BitmapLoadingWorkerJob((context as FragmentActivity), this, uri))
+                WeakReference(BitmapLoadingWorkerJob(context, this, uri))
             mBitmapLoadingWorkerJob!!.get()!!.start()
             setProgressBarVisibility()
         }
@@ -999,45 +998,49 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
             ) {
                 WeakReference(
                     BitmapCroppingWorkerJob(
-                        (context as FragmentActivity),
-                        this,
-                        imageUri,
-                        cropPoints,
-                        mDegreesRotated,
-                        orgWidth,
-                        orgHeight,
-                        mCropOverlayView!!.isFixAspectRatio,
-                        mCropOverlayView.aspectRatioX,
-                        mCropOverlayView.aspectRatioY,
-                        newReqWidth,
-                        newReqHeight,
-                        mFlipHorizontally,
-                        mFlipVertically,
-                        options,
-                        saveUri,
-                        saveCompressFormat,
-                        saveCompressQuality
+                        context = context,
+                        cropImageViewReference = WeakReference(this),
+                        uri = imageUri,
+                        bitmap = null,
+                        cropPoints = cropPoints,
+                        degreesRotated = mDegreesRotated,
+                        orgWidth = orgWidth,
+                        orgHeight = orgHeight,
+                        fixAspectRatio = mCropOverlayView!!.isFixAspectRatio,
+                        aspectRatioX = mCropOverlayView.aspectRatioX,
+                        aspectRatioY = mCropOverlayView.aspectRatioY,
+                        reqWidth = newReqWidth,
+                        reqHeight = newReqHeight,
+                        flipHorizontally = mFlipHorizontally,
+                        flipVertically = mFlipVertically,
+                        options = options,
+                        saveUri = saveUri,
+                        saveCompressFormat = saveCompressFormat,
+                        saveCompressQuality = saveCompressQuality
                     )
                 )
             } else {
                 WeakReference(
                     BitmapCroppingWorkerJob(
-                        (context as FragmentActivity),
-                        this,
-                        bitmap,
-                        cropPoints,
-                        mDegreesRotated,
-                        mCropOverlayView!!.isFixAspectRatio,
-                        mCropOverlayView.aspectRatioX,
-                        mCropOverlayView.aspectRatioY,
-                        newReqWidth,
-                        newReqHeight,
-                        mFlipHorizontally,
-                        mFlipVertically,
-                        options,
-                        saveUri,
-                        saveCompressFormat,
-                        saveCompressQuality
+                        context = context,
+                        cropImageViewReference = WeakReference(this),
+                        uri = null,
+                        bitmap = bitmap,
+                        cropPoints = cropPoints,
+                        degreesRotated = mDegreesRotated,
+                        orgWidth = 0,
+                        orgHeight = 0,
+                        fixAspectRatio = mCropOverlayView!!.isFixAspectRatio,
+                        aspectRatioX = mCropOverlayView.aspectRatioX,
+                        aspectRatioY = mCropOverlayView.aspectRatioY,
+                        reqWidth = newReqWidth,
+                        reqHeight = newReqHeight,
+                        flipHorizontally = mFlipHorizontally,
+                        flipVertically = mFlipVertically,
+                        options = options,
+                        saveUri = saveUri,
+                        saveCompressFormat = saveCompressFormat,
+                        saveCompressQuality = saveCompressQuality
                     )
                 )
             }

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,7 +1,7 @@
 ext {
 
     // Project
-    libVersion = "3.1.2"
+    libVersion = "3.1.3"
     compileSdkVersion = 30
     targetSdkVersion = 30
     minSdkVersion = 14


### PR DESCRIPTION
close #136

## Bug
### Cause:
`android.view.ContextThemeWrapper cannot be cast to androidx.fragment.app.FragmentActivity`

### Reproduce
GIVEN: Version 3.1.1 of the library, view have attibute `android:theme`
WHEN: using `CropImageView.setImageUriAsync()` method
THEN: method try to cast `ContextThemeWrapper` to `FragmentActivity`

### How the bug was solved:
Change the **WorkerJobs** to use the `Context` and for the thread we create a `CoroutineScope` inside the class
