### PR TITLE
Do not crop after pick cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Security` in case of vulnerabilities.
 
 ## [unreleased x.x.x] -
+### Fixed
+- After cropping a camera image, cancelling library picker shows again the last cropped image [#162](https://github.com/CanHub/Android-Image-Cropper/issues/162)
 
 ## [3.2.1] - 14/07/21
 ### Fixed

--- a/cropper/src/main/java/com/canhub/cropper/PickImageContract.kt
+++ b/cropper/src/main/java/com/canhub/cropper/PickImageContract.kt
@@ -23,7 +23,6 @@ open class PickImageContract : ActivityResultContract<Boolean, Uri?>() {
     protected var context: Context? = null
 
     override fun createIntent(context: Context, input: Boolean): Intent {
-
         this.context = context
 
         return CropImage.getPickImageChooserIntent(
@@ -37,16 +36,17 @@ open class PickImageContract : ActivityResultContract<Boolean, Uri?>() {
     open override fun parseResult(
         resultCode: Int,
         intent: Intent?
-    ): Uri? {
-        if (resultCode == Activity.RESULT_CANCELED) {
-            context = null
-            return null
+    ): Uri? =
+        when (resultCode) {
+            Activity.RESULT_CANCELED -> {
+                context = null
+                null
+            }
+            else -> {
+                context?.let {
+                    context = null
+                    getPickImageResultUriContent(it, intent)
+                }
+            }
         }
-        context?.let {
-            context = null
-            return getPickImageResultUriContent(it, intent)
-        }
-        context = null
-        return null
-    }
 }

--- a/cropper/src/main/java/com/canhub/cropper/PickImageContract.kt
+++ b/cropper/src/main/java/com/canhub/cropper/PickImageContract.kt
@@ -1,5 +1,6 @@
 package com.canhub.cropper
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -37,6 +38,10 @@ open class PickImageContract : ActivityResultContract<Boolean, Uri?>() {
         resultCode: Int,
         intent: Intent?
     ): Uri? {
+        if (resultCode == Activity.RESULT_CANCELED) {
+            context = null
+            return null
+        }
         context?.let {
             context = null
             return getPickImageResultUriContent(it, intent)

--- a/cropper/src/test/java/com/canhub/cropper/PickImageContractTest.kt
+++ b/cropper/src/test/java/com/canhub/cropper/PickImageContractTest.kt
@@ -57,4 +57,28 @@ class PickImageContractTest {
         // THEN
         assertEquals(expected, result)
     }
+
+    @Test
+    fun `GIVEN pick image contract and previous image selection, WHEN cancelling image pick, THEN no uri should be returned`() {
+        // GIVEN
+        var firstFragment: ContractTestFragment? = null
+        var secondFragment: ContractTestFragment? = null
+        val firstSelection = "content://testResult".toUri()
+        with(launchFragmentInContainer { ContractTestFragment(testRegistry) }) {
+            onFragment { firstFragment = it }
+        }
+        firstFragment?.pickImageIntent(true)
+        firstFragment?.pickImage?.contract?.parseResult(Activity.RESULT_OK, Intent().apply { data = firstSelection })
+        with(launchFragmentInContainer { ContractTestFragment(testRegistry) }) {
+            onFragment { secondFragment = it }
+        }
+
+        // WHEN
+        secondFragment?.pickImageIntent(true)
+        val resultIntent = Intent()
+        val result = secondFragment?.pickImage?.contract?.parseResult(Activity.RESULT_CANCELED, resultIntent)
+
+        // THEN
+        assertEquals(null, result)
+    }
 }


### PR DESCRIPTION
close #162 

## Bug
### Cause:
After cropping a file is left on the file system for later use. The picker contract doesn't respect cancellation, so if it finds that file it will (incorrectly) return it for cropping even though the user intended to _cancel_ file selection.

### Reproduce
1. Open Camera
2. Capture a Image
3. Crop a image
4. Open crop selector again
5. Don't select any image
6. return

### How the bug was solved:
Discussion on #162 suggested removing the file after cropping. However it seems to me that we can't know when to do this safely: because we return a URI to this file, we can't know whether the library's client has finished using it or not. Instead I made the picker contract explicitly respect cancellation: when cancelled, it returns no URI even if there is a file available.
