### PR TITLE
Enh/gradle cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased] 
 ### Removed
 - Removed ProGuard rule from ReadMe [#257](https://github.com/CanHub/Android-Image-Cropper/issues/257)
+- Removed unused dependencies and settings from Gradle files [#265](https://github.com/CanHub/Android-Image-Cropper/issues/265)
 
 ## [3.3.6] - 05/11/21
 ### Added

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Only need if you run on devices under OS10 (SDK 29)
 
 - Go to app level `build.gradle` file
 
-- Add this line inside ```android``` in build.gradle
+- Add this line inside ```android``` in build.gradle (Android Gradle Plugin < 4.2)
 	```gradle
 	compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ subprojects {
 allprojects {
     repositories {
         mavenCentral()
-        maven { url "https://maven.google.com" }
+        google()
         maven { url "https://jitpack.io" }
     }
 }

--- a/cropper/build.gradle
+++ b/cropper/build.gradle
@@ -25,11 +25,11 @@ afterEvaluate {
 }
 
 android {
-    compileSdkVersion rootProject.compileSdkVersion
+    compileSdk rootProject.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.minSdkVersion
-        targetSdkVersion rootProject.targetSdkVersion
+        minSdk rootProject.minSdkVersion
+        targetSdk rootProject.targetSdkVersion
         versionCode 1
         versionName rootProject.libVersion
     }
@@ -61,7 +61,6 @@ dependencies {
     implementation "androidx.exifinterface:exifinterface:$androidXExifVersion"
     implementation "androidx.core:core-ktx:$androidXCoreKtxVersion"
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$androidXLifeCycleVersion"
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"

--- a/cropper/build.gradle
+++ b/cropper/build.gradle
@@ -61,8 +61,6 @@ dependencies {
     implementation "androidx.exifinterface:exifinterface:$androidXExifVersion"
     implementation "androidx.core:core-ktx:$androidXCoreKtxVersion"
 
-    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$androidXLifeCycleVersion"
-
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
 
@@ -70,7 +68,5 @@ dependencies {
     testImplementation "androidx.test.ext:junit:$androidXJunitVersion"
     testImplementation "androidx.test:core:$androidXTestVersion"
     testImplementation "androidx.test:runner:$androidXTestVersion"
-    debugImplementation "androidx.fragment:fragment-testing:$androidXFragmentVersion"
-    testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "io.mockk:mockk:$mockkVersion"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,15 +21,6 @@ org.gradle.configureondemand=true
 # When set to true, Gradle will reuse task outputs from any previous build, when possible.
 org.gradle.caching=true
 
-# Enable Kapt Incremental annotation processing requeste
-kapt.incremental.apt=true
-
-# Decrease gradle builds time
-kapt.use.worker.api=true
-
-# turn off AP discovery in compile path, and therefore turn on Compile Avoidance
-kapt.include.compile.classpath=false
-
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,11 +38,3 @@ android.useAndroidX=true
 
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
-
-# Once you have globally enabled the Daemon in this way, all your builds will take advantage of the
-# speed boost, regardless of the version of Gradle a particular build uses.
-org.gradle.daemon=true
-
-# Run with file system watching enabled
-# https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:daemon_watch_fs
-org.gradle.vfs.watch=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,6 +35,3 @@ kapt.include.compile.classpath=false
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 # Android plugin uses the appropriate AndroidX library instead of a Support Library.
 android.useAndroidX=true
-
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion rootProject.compileSdkVersion
+    compileSdk rootProject.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion 24
-        targetSdkVersion rootProject.targetSdkVersion
+        minSdk 24
+        targetSdk rootProject.targetSdkVersion
         versionCode 1
         versionName '1.0'
     }
@@ -31,6 +31,5 @@ dependencies {
     api project(':cropper')
     implementation "androidx.appcompat:appcompat:$androidXAppCompatVersion"
     implementation "androidx.core:core-ktx:$androidXCoreKtxVersion"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation "com.google.android.material:material:$materialVersion"
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -23,16 +23,11 @@ ext {
     androidXAppCompatVersion = '1.3.1'
     androidXExifVersion = '1.3.3'
     androidXCoreKtxVersion = '1.6.0'
-    androidXLifeCycleVersion = '2.3.1'
     androidXJunitVersion = '1.1.3'
-    androidXFragmentVersion = '1.3.5'
     androidXTestVersion = '1.4.0' // when update to android 12, please uncomment PickImageContractTest && CropImageContractTest
 
     // JUnit
     junitVersion = '4.13.2'
-
-    // Robolectric
-    robolectricVersion = '4.5.1'
 
     // Mockk
     mockkVersion = '1.12.0'


### PR DESCRIPTION
close #265 

# Template 1 [New Feature]
## Description:
I have an obsession for cleanup and I noticed there are some things in Gradle related files which can be removed or changed from deprecated ones to newer ones. Source for first three bullet [here](https://zsmb.co/a-bit-of-gradle-housekeeping/).
* Since Kotlin 1.4.0, there's no need to add standard library as a dependency
* Since AGP 4.1 `compileSdkVersion`, `targetSdkVersion` and `minSdkVersion` are deprecated in favor of shorter properties of `compileSdk`, `targetSdk` and `minSdk`
* Since AGP 4.2 java 1.8 support is enabled by default. We could mention this in ReadMe.
* Jetifer could be removed, since all the dependencies are fully migrated to androidx.
* Since Gradle 7.0 "file system watching" is enabled by default. [source](https://docs.gradle.org/7.0/release-notes.html#file-system-watching)
* The Gradle Daemon is enabled by default. [source](https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:disabling_the_daemon)
* kapt properties could be removed, since kapt is not applied anywhere.
* androidx `lifeCycle`, `fragment-testing` and `robolectric` are unused and could be removed.
 
## Check list for the Code Reviewer:
* [x] CHANGELOG
* [x] README
* [ ] Wiki
* [ ] Version Number
