### PR TITLE
Close CropActivity if returning back from camera app without taking picture.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [4.0.1] - 13/12/21
+## [4.0.1] - unreleased
 ### Fixed
-- Handle a case where TakePictureContarct returns false or null .In this case ,back button should redirect us to the main screen instead of CropActivity. 
+- When TakePictureContract returns false or null return null result.  [#287](https://github.com/CanHub/Android-Image-Cropper/issues/287)
 
 
 ## [4.0.0] - 30/11/21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [4.0.է] - 13/12/21
+### Fixed
+- Handle a case where TakePictureContarct returns false or null .In this case ,back button should redirect as to the main screen instead of CropActivity. 
+
+
 ## [4.0.0] - 30/11/21
 ### Fixed
 - Issue where some devices based on MIUI would not retrieve image from gallery [#253](https://github.com/CanHub/Android-Image-Cropper/issues/253)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [4.0.1] - 13/12/21
 ### Fixed
-- Handle a case where TakePictureContarct returns false or null .In this case ,back button should redirect as to the main screen instead of CropActivity. 
+- Handle a case where TakePictureContarct returns false or null .In this case ,back button should redirect us to the main screen instead of CropActivity. 
 
 
 ## [4.0.0] - 30/11/21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [4.0.է] - 13/12/21
+## [4.0.1] - 13/12/21
 ### Fixed
 - Handle a case where TakePictureContarct returns false or null .In this case ,back button should redirect as to the main screen instead of CropActivity. 
 

--- a/cropper/src/main/java/com/canhub/cropper/CropImageActivity.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageActivity.kt
@@ -44,7 +44,7 @@ open class CropImageActivity :
             onPickImageResult(uri)
         }
     private val takePicture = registerForActivityResult(ActivityResultContracts.TakePicture()) {
-        if (it) onPickImageResult(latestTmpUri)
+        if (it) onPickImageResult(latestTmpUri) else onPickImageResult(null)
     }
 
     public override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
Close crop activity  when user returns from camera app without taking picture ( back button) , in that case crop activity must not be shown.

how to reproduce/test

click TAKE CAMERA PIC ... WITH URI, when camera opens , click back button .
It still shows the crop activity , without any image, but should close the activity when TakeCamera() contract result is null or false.