### PR TITLE
Java sample authority bug

### DIFF
--- a/sample/src/main/java/com/canhub/cropper/sample/crop_image_java/app/SCropImageFragmentJava.java
+++ b/sample/src/main/java/com/canhub/cropper/sample/crop_image_java/app/SCropImageFragmentJava.java
@@ -45,7 +45,7 @@ public class SCropImageFragmentJava extends Fragment implements SCropImageContra
     static final String FILE_NAMING_PREFIX = "JPEG_";
     static final String FILE_NAMING_SUFFIX = "_";
     static final String FILE_FORMAT = ".jpg";
-    static final String AUTHORITY_SUFFIX = ".fileprovider";
+    static final String AUTHORITY_SUFFIX = ".cropper.fileprovider";
 
     private FragmentCameraBinding binding;
     private final SCropImageContractJava.Presenter presenter = new SCropImagePresenterJava();


### PR DESCRIPTION
close #301 

## Bug
### Cause:
Forgot yo update the authority value for java code

### Reproduce
In the issue

### How the bug was solved:
Update the Authority value as we have in the kotlin code
