### PR TITLE
Release/4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [unreleased 4.0.2]
-### Added
-- Added provision to add Oval crop corners when the crop style is Rectangle [#305](https://github.com/CanHub/Android-Image-Cropper/issues/305)
+## [4.2.0] - unreleased
 
-## [4.0.1] - unreleased
+## [4.1.0] - 02/02/2022
 ### Fixed
 - When TakePictureContract returns false or null return null result.  [#287](https://github.com/CanHub/Android-Image-Cropper/issues/287)
+### Added
+- Added provision to add Oval crop corners when the crop style is Rectangle [#305](https://github.com/CanHub/Android-Image-Cropper/issues/305)
 
 
 ## [4.0.0] - 30/11/21

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![](https://jitpack.io/v/CanHub/Android-Image-Cropper.svg)](https://jitpack.io/#CanHub/Android-Image-Cropper)
 
 [🚨How to migrate from ArthurHub/Android-Image-Cropper🚨](https://github.com/CanHub/Android-Image-Cropper/wiki/🚨-How-to-migrate-Android-Image-Cropper--🚨)
+
 [Java Sample Code](https://github.com/CanHub/Android-Image-Cropper/tree/main/sample/src/main/java/com/canhub/cropper/sample/crop_image_java)
 
 Wanna help the project? Amazing!

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![](https://jitpack.io/v/CanHub/Android-Image-Cropper.svg)](https://jitpack.io/#CanHub/Android-Image-Cropper)
 
 [🚨How to migrate from ArthurHub/Android-Image-Cropper🚨](https://github.com/CanHub/Android-Image-Cropper/wiki/🚨-How-to-migrate-Android-Image-Cropper--🚨)
+[Java Sample Code](https://github.com/CanHub/Android-Image-Cropper/tree/main/sample/src/main/java/com/canhub/cropper/sample/crop_image_java)
 
 Wanna help the project? Amazing!
 - [Contributing Guide](https://github.com/CanHub/Android-Image-Cropper/blob/main/CONTRIBUTING.md)

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,7 +1,7 @@
 ext {
 
     // Project
-    libVersion = "4.0.0"
+    libVersion = "4.1.0"
     compileSdkVersion = 31
     targetSdkVersion = 31
     minSdkVersion = 16


### PR DESCRIPTION
## [4.1.0] - 02/02/2022
### Fixed
- When TakePictureContract returns false or null return null result.  [#287](https://github.com/CanHub/Android-Image-Cropper/issues/287)
### Added
- Added provision to add Oval crop corners when the crop style is Rectangle [#305](https://github.com/CanHub/Android-Image-Cropper/issues/305)