### PR TITLE
resolve shadow bug (issue #261)

### DIFF
--- a/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
@@ -559,7 +559,6 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
     fun getCroppedImage(reqWidth: Int, reqHeight: Int, options: RequestSizeOptions): Bitmap? {
         var croppedBitmap: Bitmap? = null
         if (originalBitmap != null) {
-            imageView.clearAnimation()
             val newReqWidth = if (options != RequestSizeOptions.NONE) reqWidth else 0
             val newReqHeight = if (options != RequestSizeOptions.NONE) reqHeight else 0
             croppedBitmap = if (imageUri != null &&
@@ -894,7 +893,6 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
         degreesRotated: Int
     ) {
         if (originalBitmap == null || originalBitmap != bitmap) {
-            imageView.clearAnimation()
             clearImageInt()
             originalBitmap = bitmap
             imageView.setImageBitmap(originalBitmap)
@@ -967,7 +965,6 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
     ) {
         val bitmap = originalBitmap
         if (bitmap != null) {
-            imageView.clearAnimation()
             val currentTask =
                 if (bitmapCroppingWorkerJob != null) bitmapCroppingWorkerJob!!.get() else null
             currentTask?.cancel()


### PR DESCRIPTION
resolved shadow bug #261 

## Bug
### Cause:
when using CropImageView and a `setOnSetCropOverlayReleasedListener` or `setOnSetCropOverlayMovedListener` to transfer the cropped Bitmap into something else, the image would not zoom anymore but display halftransparent black borders.
the image would then snap back into correct zoom level when touching any border with the cropOverlay rectangle.

this was caused by the `getCroppedImage()` or `startCropWorkerTask()` async functions.
they called `imageView.clearAnimation()` which in turn killed the zoom animation prematurely.

### Reproduce
GIVEN: using CropImageView
WHEN: having a Listener on OverlayReleased or OverlayMoved that got the cropped Bitmap directly or via Async
THEN: shadow borders occur and image zoom does not get applied

### How the bug was solved:
removed imageView.clearAnimation() since it appearantly didn't do anything anyways...
