### PR TITLE
Add support for ScaleType.CENTER_CROP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Security` in case of vulnerabilities.
 
 ## [4.2.0] - unreleased
+### Fixed
+- Added missing support for `ScaleType.CENTER_CROP` https://github.com/CanHub/Android-Image-Cropper/issues/220
 
 ## [4.1.0] - 02/02/2022
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [4.2.0] - unreleased
 ### Fixed
-- Added missing support for `ScaleType.CENTER_CROP` https://github.com/CanHub/Android-Image-Cropper/issues/220
+- Added missing support for `ScaleType.CENTER_CROP` [#220](https://github.com/CanHub/Android-Image-Cropper/issues/220)
 
 ## [4.1.0] - 02/02/2022
 ### Fixed

--- a/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
@@ -1303,6 +1303,11 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
                     BitmapUtils.getRectCenterY(mImagePoints)
                 )
                 mapImagePointsByImageMatrix()
+            } else if (mScaleType == ScaleType.CENTER_CROP) {
+                mZoom = max(
+                    getWidth() / BitmapUtils.getRectWidth(mImagePoints),
+                    getHeight() / BitmapUtils.getRectHeight(mImagePoints)
+                );
             }
             // scale by the current zoom level
             val scaleX = if (mFlipHorizontally) -mZoom else mZoom
@@ -1315,7 +1320,11 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
             )
             mapImagePointsByImageMatrix()
             mImageMatrix.mapRect(cropRect)
-            if (center) {
+
+            if (mScaleType == ScaleType.CENTER_CROP && center && !animate) {
+                mZoomOffsetX = 0f
+                mZoomOffsetY = 0f
+            } else if (center) {
                 // set the zoomed area to be as to the center of cropping window as possible
                 mZoomOffsetX =
                     if (width > BitmapUtils.getRectWidth(mImagePoints)) 0f

--- a/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
@@ -1307,7 +1307,7 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
                 mZoom = max(
                     getWidth() / BitmapUtils.getRectWidth(mImagePoints),
                     getHeight() / BitmapUtils.getRectHeight(mImagePoints)
-                );
+                )
             }
             // scale by the current zoom level
             val scaleX = if (mFlipHorizontally) -mZoom else mZoom


### PR DESCRIPTION
Adds support for `ScaleType.CENTER_CROP` flag - previously this would be ignored and would leave some space on either side of the view.

Closes https://github.com/CanHub/Android-Image-Cropper/issues/220

I would appreciate you testing this on your side @Canato, @PiotrBandurski - this helps with our use-case but the chance is that it breakes somebody elses.

