### PR TITLE
Added skip editing option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [4.2.0] - unreleased
 ### Fixed
 - Added missing support for `ScaleType.CENTER_CROP` [#220](https://github.com/CanHub/Android-Image-Cropper/issues/220)
+### Added
+- Added an option to skip manual editing and return entire image when required [#324](https://github.com/CanHub/Android-Image-Cropper/pull/324)
 
 ## [4.1.0] - 02/02/2022
 ### Fixed

--- a/cropper/src/main/java/com/canhub/cropper/CropImageActivity.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageActivity.kt
@@ -135,6 +135,7 @@ open class CropImageActivity :
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        if (cropImageOptions.skipEditing) return true
         menuInflater.inflate(R.menu.crop_image_menu, menu)
 
         if (!cropImageOptions.allowRotation) {
@@ -218,6 +219,10 @@ open class CropImageActivity :
 
             if (cropImageOptions.initialRotation > 0)
                 cropImageView?.rotatedDegrees = cropImageOptions.initialRotation
+
+            if (cropImageOptions.skipEditing) {
+                cropImage()
+            }
         } else setResult(null, error, 1)
     }
 

--- a/cropper/src/main/java/com/canhub/cropper/CropImageContractOptions.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageContractOptions.kt
@@ -490,6 +490,16 @@ data class CropImageContractOptions @JvmOverloads constructor(
         cropImageOptions.cropMenuCropButtonIcon = drawableResource
         return this
     }
+
+    /**
+     * Set whether the cropping option should be allowed or skipped entirely.<br></br>
+     * *Default: false*
+     */
+    fun setSkipEditing(skipEditing: Boolean): CropImageContractOptions {
+        cropImageOptions.skipEditing = skipEditing
+        cropImageOptions.showCropOverlay = !skipEditing
+        return this
+    }
 }
 
 fun options(

--- a/cropper/src/main/java/com/canhub/cropper/CropImageOptions.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageOptions.kt
@@ -285,8 +285,8 @@ open class CropImageOptions : Parcelable {
     var cropMenuCropButtonIcon: Int
 
     /**
-     * Allows you to skip the cropping option.
-     * This returns the entire image
+     * Allows you to skip the editing (cropping, flipping or rotating) option.
+     * This returns the entire selected image directly
      */
     @JvmField
     var skipEditing: Boolean

--- a/cropper/src/main/java/com/canhub/cropper/CropImageOptions.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageOptions.kt
@@ -284,6 +284,13 @@ open class CropImageOptions : Parcelable {
     @JvmField
     var cropMenuCropButtonIcon: Int
 
+    /**
+     * Allows you to skip the cropping option.
+     * This returns the entire image
+     */
+    @JvmField
+    var skipEditing: Boolean
+
     /** Init options with defaults.  */
     constructor() {
         val dm = Resources.getSystem().displayMetrics
@@ -342,6 +349,7 @@ open class CropImageOptions : Parcelable {
         flipVertically = false
         cropMenuCropButtonTitle = null
         cropMenuCropButtonIcon = 0
+        skipEditing = false
     }
 
     /** Create object from parcel.  */
@@ -400,6 +408,7 @@ open class CropImageOptions : Parcelable {
         flipVertically = parcel.readByte().toInt() != 0
         cropMenuCropButtonTitle = TextUtils.CHAR_SEQUENCE_CREATOR.createFromParcel(parcel)
         cropMenuCropButtonIcon = parcel.readInt()
+        skipEditing = parcel.readByte().toInt() != 0
     }
 
     override fun writeToParcel(dest: Parcel, flags: Int) {
@@ -457,6 +466,7 @@ open class CropImageOptions : Parcelable {
         dest.writeByte((if (flipVertically) 1 else 0).toByte())
         TextUtils.writeToParcel(cropMenuCropButtonTitle, dest, flags)
         dest.writeInt(cropMenuCropButtonIcon)
+        dest.writeByte((if (skipEditing) 1 else 0).toByte())
     }
 
     override fun describeContents(): Int {

--- a/sample/src/main/java/com/canhub/cropper/sample/crop_image/app/SCropImageFragment.kt
+++ b/sample/src/main/java/com/canhub/cropper/sample/crop_image/app/SCropImageFragment.kt
@@ -190,7 +190,7 @@ internal class SCropImageFragment : Fragment(), SCropImageContract.View {
 //                setAllowRotation(false)
 //                setNoOutputImage(false)
 //                setFixAspectRatio(true)
-//                setSkipCropping(true)
+//                setSkipEditing(true)
             }
         )
     }

--- a/sample/src/main/java/com/canhub/cropper/sample/crop_image/app/SCropImageFragment.kt
+++ b/sample/src/main/java/com/canhub/cropper/sample/crop_image/app/SCropImageFragment.kt
@@ -190,6 +190,7 @@ internal class SCropImageFragment : Fragment(), SCropImageContract.View {
 //                setAllowRotation(false)
 //                setNoOutputImage(false)
 //                setFixAspectRatio(true)
+//                setSkipCropping(true)
             }
         )
     }


### PR DESCRIPTION
closes #323 

# Added an option to skip editing the selected image entirely when not required[New Feature]
## Description:
The user can now set an option to skip editing (cropping, flipping or rotating) the image entirely when not required. This can be useful when some places in your app don't require the image to be edited but you still want to use this library because of it's great functionality of picking and choosing images. This will help reduce user interactions in such cases
