### PR TITLE
Preserve state across configuration changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [4.2.0] - unreleased
 ### Fixed
 - Added missing support for `ScaleType.CENTER_CROP` [#220](https://github.com/CanHub/Android-Image-Cropper/issues/220)
+- State is now preserved across configuration changes [#296](https://github.com/CanHub/Android-Image-Cropper/issues/296)
 ### Added
 - Added an option to skip manual editing and return entire image when required [#324](https://github.com/CanHub/Android-Image-Cropper/pull/324)
 

--- a/cropper/src/main/java/com/canhub/cropper/CropImageActivity.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageActivity.kt
@@ -13,6 +13,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.BlendModeColorFilterCompat
 import androidx.core.graphics.BlendModeCompat
+import androidx.core.net.toUri
 import com.canhub.cropper.CropImageView.CropResult
 import com.canhub.cropper.CropImageView.OnCropImageCompleteListener
 import com.canhub.cropper.CropImageView.OnSetImageUriCompleteListener
@@ -71,6 +72,8 @@ open class CropImageActivity :
                     else -> finish()
                 }
             } else cropImageView?.setImageUriAsync(cropImageUri)
+        } else {
+            latestTmpUri = savedInstanceState.getString(BUNDLE_KEY_TMP_URI)?.toUri()
         }
 
         supportActionBar?.let {
@@ -132,6 +135,11 @@ open class CropImageActivity :
         super.onStop()
         cropImageView?.setOnSetImageUriCompleteListener(null)
         cropImageView?.setOnCropImageCompleteListener(null)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putString(BUNDLE_KEY_TMP_URI, latestTmpUri.toString())
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -323,4 +331,8 @@ open class CropImageActivity :
     }
 
     enum class Source { CAMERA, GALLERY }
+
+    private companion object {
+        const val BUNDLE_KEY_TMP_URI = "bundle_key_tmp_uri"
+    }
 }


### PR DESCRIPTION
close #296 

## Bug
### Cause:

1. Inside the `CropImageActivity` the `latestTmpUri` variable is reset during configuration changes (such as rotation).
2. The `CropImageView` incorrectly saves the current bitmap uri inside the `onSaveStateInstance()`.

### How the bug was solved:

1. The `latestTmpUri` is now saved inside the `onSaveInstanceState()`.
2. I modified the code according to the original code [here](https://github.com/ArthurHub/Android-Image-Cropper/blob/master/cropper/src/main/java/com/theartofdev/edmodo/cropper/CropImageView.java#L1338). Besides, the `saveInstanceStateBitmapUri` variable is no longer needed. It seems that the `customOutputUri` is used in its place now.
