### PR TITLE
Bug fixed by adding setCancelable(false)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Security` in case of vulnerabilities.
 
 ## [x.x.x] - unreleased
-
+### Fixed
+- Fix disable closing AlertDialog when touching outside the dialog [#334](https://github.com/CanHub/Android-Image-Cropper/issues/334)
 ## [4.2.0] - 21/03/2022
 ### Added
 - Added an option to skip manual editing and return entire image when required [#324](https://github.com/CanHub/Android-Image-Cropper/pull/324)

--- a/cropper/src/main/java/com/canhub/cropper/CropImageActivity.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageActivity.kt
@@ -115,6 +115,7 @@ open class CropImageActivity :
      */
     open fun showImageSourceDialog(openSource: (Source) -> Unit) {
         AlertDialog.Builder(this)
+            .setCancelable(false)
             .setTitle(R.string.pick_image_chooser_title)
             .setItems(
                 arrayOf(


### PR DESCRIPTION
_Add the issue linked to this PR_
close #334 

# Template 2 [Bug]
## Bug 
### Cause:
The AlertDialog Builder was lacking the .setCancelable(false) statement to disable closing the alert by touching outside it.

### Reproduce
-Create a new Activity using CropImageActivity as explained in the documentation.
-Launch the Dialog with showImageSourceDialog.
-Tap outside the screen.
-AlertDialog closed.

### How the bug was solved:
I added the statement .setCancelable(false) to disable closing the AlertDialog.