### PR TITLE
Translation of "Camera" and "Gallery" added in some languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - `Security` in case of vulnerabilities.
 
 ## [x.x.x] - unreleased
+### Fixed
+- The translation of `Camera` and `Gallery` does not exist in some languages.
 
 ## [4.2.1] - 04/04/2022
 ### Added

--- a/cropper/src/main/res/values-ar/strings.xml
+++ b/cropper/src/main/res/values-ar/strings.xml
@@ -8,9 +8,9 @@
     <string name="ic_flip_24">اقلب</string>
     <string name="ic_flip_24_horizontally">اقلب أفقيًا</string>
     <string name="ic_flip_24_vertically">اقلب رأسيًا</string>
-
     <string name="pick_image_chooser_title">اختر مصدرًا</string>
-
+    <string name="pick_image_camera">الة تصوير</string>
+    <string name="pick_image_gallery">صالة عرض</string>
     <string name="crop_image_activity_no_permissions">إلغاء؛ الأذونات المطلوبة غير ممنوحة</string>
 
 </resources>

--- a/cropper/src/main/res/values-de/strings.xml
+++ b/cropper/src/main/res/values-de/strings.xml
@@ -8,9 +8,9 @@
     <string name="ic_flip_24">spiegeln</string>
     <string name="ic_flip_24_horizontally">horizontal spiegeln</string>
     <string name="ic_flip_24_vertically">vertikal spiegeln</string>
-
     <string name="pick_image_chooser_title">Quelle wählen</string>
-
+    <string name="pick_image_camera">Kamera</string>
+    <string name="pick_image_gallery">Galerie</string>
     <string name="crop_image_activity_no_permissions">Vorgang wird abgebrochen, benötigte Berechtigungen wurden nicht erteilt.</string>
 
 </resources>

--- a/cropper/src/main/res/values-es-rGT/strings.xml
+++ b/cropper/src/main/res/values-es-rGT/strings.xml
@@ -8,5 +8,7 @@
     <string name="ic_flip_24_horizontally">Voltear horizontalmente</string>
     <string name="ic_flip_24_vertically">Voltear verticalmente</string>
     <string name="pick_image_chooser_title">Seleccionar fuente</string>
+    <string name="pick_image_camera">Cámara</string>
+    <string name="pick_image_gallery">Galería</string>
     <string name="crop_image_activity_no_permissions">Cancelando, los permisos requeridos no se otorgaron</string>
 </resources>

--- a/cropper/src/main/res/values-es/strings.xml
+++ b/cropper/src/main/res/values-es/strings.xml
@@ -5,8 +5,10 @@
     <string name="ic_rotate_right_24">Rotar a la derecha</string>
     <string name="crop_image_menu_crop">Cortar</string>
     <string name="ic_flip_24">Dar la vuelta</string>
-    <string name="ic_flip_24_horizontally">Voltear horizontalmente</string>
-    <string name="ic_flip_24_vertically">Voltear verticalmente</string>
+    <string name="ic_flip_24_horizontally">Girar horizontalmente</string>
+    <string name="ic_flip_24_vertically">Girar verticalmente</string>
     <string name="pick_image_chooser_title">Seleccionar fuente</string>
+    <string name="pick_image_camera">Cámara</string>
+    <string name="pick_image_gallery">Galería</string>
     <string name="crop_image_activity_no_permissions">Cancelando, los permisos requeridos no han sido otorgados</string>
 </resources>

--- a/cropper/src/main/res/values-fr/strings.xml
+++ b/cropper/src/main/res/values-fr/strings.xml
@@ -8,5 +8,7 @@
     <string name="ic_flip_24_horizontally">Retourner horizontalement</string>
     <string name="ic_flip_24_vertically">Retourner verticalement</string>
     <string name="pick_image_chooser_title">Sélectionner la source</string>
+    <string name="pick_image_camera">Appareil photo</string>
+    <string name="pick_image_gallery">Galerie</string>
     <string name="crop_image_activity_no_permissions">Annulation, il manque des permissions requises</string>
 </resources>

--- a/cropper/src/main/res/values-it/strings.xml
+++ b/cropper/src/main/res/values-it/strings.xml
@@ -10,7 +10,8 @@
     <string name="ic_flip_24_vertically">Capovolgi verticalmente</string>
 
     <string name="pick_image_chooser_title">Seleziona origine</string>
-
+    <string name="pick_image_camera">Fotocamera</string>
+    <string name="pick_image_gallery">Galleria</string>
     <string name="crop_image_activity_no_permissions">Annullamento in corso, autorizzazione richieste non concesse</string>
 
 </resources>

--- a/cropper/src/main/res/values-nl/strings.xml
+++ b/cropper/src/main/res/values-nl/strings.xml
@@ -8,9 +8,9 @@
     <string name="ic_flip_24">Spiegelen</string>
     <string name="ic_flip_24_horizontally">Horizontaal spiegelen</string>
     <string name="ic_flip_24_vertically">Verticaal spiegelen</string>
-
     <string name="pick_image_chooser_title">Bron selecteren</string>
-
+    <string name="pick_image_camera">Camera</string>
+    <string name="pick_image_gallery">Galerij</string>
     <string name="crop_image_activity_no_permissions">Wordt geannuleerd, vereiste machtigingen zijn niet toegekend</string>
 
 </resources>


### PR DESCRIPTION
_Add the issue linked to this PR_
close [#357](https://github.com/CanHub/Android-Image-Cropper/issues/357)

## Bug
### Cause:
When the source selector is displayed, the texts are always in English.

### Reproduce
Displays the source picker dialog.

### How the bug was solved:
Translations for the following languages are added:
- Spanish (ES, GT)
- Italian
- German
- Arabic
- Dutch
- French