### PR TITLE
CropImageView: Use customOutputUri instance property as a fallback in startCropWorkerTask.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x] - unreleased
 
+- CropImageView: Use customOutputUri instance property as a fallback in startCropWorkerTask. [#401](https://github.com/CanHub/Android-Image-Cropper/issues/401)
 - CropImageOptions: Option to change progress bar color. [#390](https://github.com/CanHub/Android-Image-Cropper/issues/390)
 - Sample: Showcase 2:1 aspect ratio. [#386](https://github.com/CanHub/Android-Image-Cropper/issues/386)
 - Update dependencies [#387](https://github.com/CanHub/Android-Image-Cropper/issues/387)

--- a/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
@@ -653,7 +653,7 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
             options = options,
             saveCompressFormat = saveCompressFormat,
             saveCompressQuality = saveCompressQuality,
-            customOutputUri = customOutputUri
+            customOutputUri = customOutputUri,
         )
     }
 
@@ -1018,7 +1018,7 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
                     options = options,
                     saveCompressFormat = saveCompressFormat,
                     saveCompressQuality = saveCompressQuality,
-                    customOutputUri = customOutputUri,
+                    customOutputUri = customOutputUri ?: this.customOutputUri,
                 )
             )
 


### PR DESCRIPTION
I was surprised when setting `view.customOutputUri` didn't do what I thought it did when manually calling `croppedImageAsync` which internally calls `startCropWorkerTask`.