### PR TITLE
fix(exif-orientation): added support for exif values 2, 4, 5 and 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x] - unreleased
 
+- CropImageView: Added support for handling all EXIF orientation values. [#408](https://github.com/CanHub/Android-Image-Cropper/issues/408)
 - CropImageView: Use customOutputUri instance property as a fallback in startCropWorkerTask. [#401](https://github.com/CanHub/Android-Image-Cropper/issues/401)
 - CropImageOptions: Option to change progress bar color. [#390](https://github.com/CanHub/Android-Image-Cropper/issues/390)
 - Sample: Showcase 2:1 aspect ratio. [#386](https://github.com/CanHub/Android-Image-Cropper/issues/386)

--- a/cropper/src/main/java/com/canhub/cropper/BitmapLoadingWorkerJob.kt
+++ b/cropper/src/main/java/com/canhub/cropper/BitmapLoadingWorkerJob.kt
@@ -124,8 +124,14 @@ class BitmapLoadingWorkerJob internal constructor(
         fun getUriFilePath(context: Context, uniqueName: Boolean = false): String =
             getFilePathFromUri(context, uriContent, uniqueName)
 
-        internal constructor(uri: Uri, bitmap: Bitmap?, loadSampleSize: Int, degreesRotated: Int,
-                             flipHorizontally: Boolean, flipVertically: Boolean) {
+        internal constructor(
+            uri: Uri,
+            bitmap: Bitmap?,
+            loadSampleSize: Int,
+            degreesRotated: Int,
+            flipHorizontally: Boolean,
+            flipVertically: Boolean
+        ) {
             uriContent = uri
             this.bitmap = bitmap
             this.loadSampleSize = loadSampleSize

--- a/cropper/src/main/java/com/canhub/cropper/BitmapLoadingWorkerJob.kt
+++ b/cropper/src/main/java/com/canhub/cropper/BitmapLoadingWorkerJob.kt
@@ -40,14 +40,16 @@ class BitmapLoadingWorkerJob internal constructor(
                     val decodeResult =
                         BitmapUtils.decodeSampledBitmap(context, uri, width, height)
                     if (isActive) {
-                        val rotateResult =
-                            BitmapUtils.rotateBitmapByExif(decodeResult.bitmap, context, uri)
+                        val orientateResult =
+                            BitmapUtils.orientateBitmapByExif(decodeResult.bitmap, context, uri)
                         onPostExecute(
                             Result(
                                 uri = uri,
-                                bitmap = rotateResult.bitmap,
+                                bitmap = orientateResult.bitmap,
                                 loadSampleSize = decodeResult.sampleSize,
-                                degreesRotated = rotateResult.degrees
+                                degreesRotated = orientateResult.degrees,
+                                flipHorizontally = orientateResult.flipHorizontally,
+                                flipVertically = orientateResult.flipVertically
                             )
                         )
                     }
@@ -87,6 +89,7 @@ class BitmapLoadingWorkerJob internal constructor(
     companion object
     class Result {
 
+
         /**
          * The Android URI of the image to load.
          * NOT a file path, for it use [getUriFilePath]
@@ -102,6 +105,12 @@ class BitmapLoadingWorkerJob internal constructor(
         /** The degrees the image was rotated  */
         val degreesRotated: Int
 
+        /** If the image was flipped horizontally */
+        var flipHorizontally: Boolean = false
+
+        /** If the image was flipped vertically */
+        var flipVertically: Boolean = false
+
         /** The error that occurred during async bitmap loading.  */
         val error: Exception?
 
@@ -116,11 +125,13 @@ class BitmapLoadingWorkerJob internal constructor(
         fun getUriFilePath(context: Context, uniqueName: Boolean = false): String =
             getFilePathFromUri(context, uriContent, uniqueName)
 
-        internal constructor(uri: Uri, bitmap: Bitmap?, loadSampleSize: Int, degreesRotated: Int) {
+        internal constructor(uri: Uri, bitmap: Bitmap?, loadSampleSize: Int, degreesRotated: Int, flipHorizontally: Boolean, flipVertically: Boolean) {
             uriContent = uri
             this.bitmap = bitmap
             this.loadSampleSize = loadSampleSize
             this.degreesRotated = degreesRotated
+            this.flipHorizontally = flipHorizontally
+            this.flipVertically = flipVertically
             error = null
         }
 

--- a/cropper/src/main/java/com/canhub/cropper/BitmapLoadingWorkerJob.kt
+++ b/cropper/src/main/java/com/canhub/cropper/BitmapLoadingWorkerJob.kt
@@ -89,7 +89,6 @@ class BitmapLoadingWorkerJob internal constructor(
     companion object
     class Result {
 
-
         /**
          * The Android URI of the image to load.
          * NOT a file path, for it use [getUriFilePath]

--- a/cropper/src/main/java/com/canhub/cropper/BitmapLoadingWorkerJob.kt
+++ b/cropper/src/main/java/com/canhub/cropper/BitmapLoadingWorkerJob.kt
@@ -124,7 +124,8 @@ class BitmapLoadingWorkerJob internal constructor(
         fun getUriFilePath(context: Context, uniqueName: Boolean = false): String =
             getFilePathFromUri(context, uriContent, uniqueName)
 
-        internal constructor(uri: Uri, bitmap: Bitmap?, loadSampleSize: Int, degreesRotated: Int, flipHorizontally: Boolean, flipVertically: Boolean) {
+        internal constructor(uri: Uri, bitmap: Bitmap?, loadSampleSize: Int, degreesRotated: Int,
+                             flipHorizontally: Boolean, flipVertically: Boolean) {
             uriContent = uri
             this.bitmap = bitmap
             this.loadSampleSize = loadSampleSize

--- a/cropper/src/main/java/com/canhub/cropper/BitmapUtils.kt
+++ b/cropper/src/main/java/com/canhub/cropper/BitmapUtils.kt
@@ -102,10 +102,10 @@ internal object BitmapUtils {
             ExifInterface.ORIENTATION_ROTATE_270 -> 270
             else -> 0
         }
-        val flipHorizontally = orientationAttributeInt == ExifInterface.ORIENTATION_FLIP_HORIZONTAL
-            || orientationAttributeInt == ExifInterface.ORIENTATION_TRANSPOSE
-        val flipVertically = orientationAttributeInt == ExifInterface.ORIENTATION_FLIP_VERTICAL
-            || orientationAttributeInt == ExifInterface.ORIENTATION_TRANSVERSE
+        val flipHorizontally = orientationAttributeInt == ExifInterface.ORIENTATION_FLIP_HORIZONTAL ||
+            orientationAttributeInt == ExifInterface.ORIENTATION_TRANSPOSE
+        val flipVertically = orientationAttributeInt == ExifInterface.ORIENTATION_FLIP_VERTICAL ||
+            orientationAttributeInt == ExifInterface.ORIENTATION_TRANSVERSE
         return RotateBitmapResult(bitmap, degrees, flipHorizontally, flipVertically)
     }
 
@@ -724,8 +724,8 @@ internal object BitmapUtils {
             options.inSampleSize = (
                 sampleMulti
                     * calculateInSampleSizeByReqestedSize(
-                    rect.width(), rect.height(), reqWidth, reqHeight
-                )
+                        rect.width(), rect.height(), reqWidth, reqHeight
+                    )
                 )
             val stream = context.contentResolver.openInputStream(uri)
             val decoder = BitmapRegionDecoder.newInstance(stream!!, false)

--- a/cropper/src/main/java/com/canhub/cropper/BitmapUtils.kt
+++ b/cropper/src/main/java/com/canhub/cropper/BitmapUtils.kt
@@ -74,7 +74,7 @@ internal object BitmapUtils {
      * If no rotation is required the image will not be rotated.<br></br>
      * New bitmap is created and the old one is recycled.
      */
-    fun rotateBitmapByExif(bitmap: Bitmap?, context: Context, uri: Uri?): RotateBitmapResult {
+    fun orientateBitmapByExif(bitmap: Bitmap?, context: Context, uri: Uri?): RotateBitmapResult {
         var ei: ExifInterface? = null
         try {
             val `is` = context.contentResolver.openInputStream(uri!!)
@@ -84,7 +84,7 @@ internal object BitmapUtils {
             }
         } catch (ignored: Exception) {
         }
-        return if (ei != null) rotateBitmapByExif(bitmap, ei) else RotateBitmapResult(bitmap, 0)
+        return if (ei != null) orientateBitmapByExif(bitmap, ei) else RotateBitmapResult(bitmap, 0)
     }
 
     /**
@@ -92,19 +92,17 @@ internal object BitmapUtils {
      * If no rotation is required the image will not be rotated.<br></br>
      * New bitmap is created and the old one is recycled.
      */
-    fun rotateBitmapByExif(bitmap: Bitmap?, exif: ExifInterface): RotateBitmapResult {
-        val degrees: Int = when (
-            exif.getAttributeInt(
-                ExifInterface.TAG_ORIENTATION,
-                ExifInterface.ORIENTATION_NORMAL
-            )
-        ) {
-            ExifInterface.ORIENTATION_ROTATE_90 -> 90
+    fun orientateBitmapByExif(bitmap: Bitmap?, exif: ExifInterface): RotateBitmapResult {
+        val orientationAttributeInt = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+        val degrees: Int = when (orientationAttributeInt) {
+            ExifInterface.ORIENTATION_ROTATE_90, ExifInterface.ORIENTATION_TRANSVERSE, ExifInterface.ORIENTATION_TRANSPOSE -> 90
             ExifInterface.ORIENTATION_ROTATE_180 -> 180
             ExifInterface.ORIENTATION_ROTATE_270 -> 270
             else -> 0
         }
-        return RotateBitmapResult(bitmap, degrees)
+        val flipHorizontally = orientationAttributeInt == ExifInterface.ORIENTATION_FLIP_HORIZONTAL || orientationAttributeInt == ExifInterface.ORIENTATION_TRANSPOSE
+        val flipVertically = orientationAttributeInt == ExifInterface.ORIENTATION_FLIP_VERTICAL || orientationAttributeInt == ExifInterface.ORIENTATION_TRANSVERSE
+        return RotateBitmapResult(bitmap, degrees, flipHorizontally, flipVertically)
     }
 
     /**
@@ -970,6 +968,14 @@ internal object BitmapUtils {
         /**
          * The degrees the image was rotated
          */
-        val degrees: Int
+        val degrees: Int,
+        /**
+         * If the image was flipped horizontally
+         */
+        val flipHorizontally: Boolean = false,
+        /**
+         * If the image was flipped vertically
+         */
+        val flipVertically: Boolean = false
     )
 }

--- a/cropper/src/main/java/com/canhub/cropper/BitmapUtils.kt
+++ b/cropper/src/main/java/com/canhub/cropper/BitmapUtils.kt
@@ -93,15 +93,19 @@ internal object BitmapUtils {
      * New bitmap is created and the old one is recycled.
      */
     fun orientateBitmapByExif(bitmap: Bitmap?, exif: ExifInterface): RotateBitmapResult {
-        val orientationAttributeInt = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+        val orientationAttributeInt =
+            exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
         val degrees: Int = when (orientationAttributeInt) {
-            ExifInterface.ORIENTATION_ROTATE_90, ExifInterface.ORIENTATION_TRANSVERSE, ExifInterface.ORIENTATION_TRANSPOSE -> 90
+            ExifInterface.ORIENTATION_ROTATE_90, ExifInterface.ORIENTATION_TRANSVERSE,
+            ExifInterface.ORIENTATION_TRANSPOSE -> 90
             ExifInterface.ORIENTATION_ROTATE_180 -> 180
             ExifInterface.ORIENTATION_ROTATE_270 -> 270
             else -> 0
         }
-        val flipHorizontally = orientationAttributeInt == ExifInterface.ORIENTATION_FLIP_HORIZONTAL || orientationAttributeInt == ExifInterface.ORIENTATION_TRANSPOSE
-        val flipVertically = orientationAttributeInt == ExifInterface.ORIENTATION_FLIP_VERTICAL || orientationAttributeInt == ExifInterface.ORIENTATION_TRANSVERSE
+        val flipHorizontally = orientationAttributeInt == ExifInterface.ORIENTATION_FLIP_HORIZONTAL
+            || orientationAttributeInt == ExifInterface.ORIENTATION_TRANSPOSE
+        val flipVertically = orientationAttributeInt == ExifInterface.ORIENTATION_FLIP_VERTICAL
+            || orientationAttributeInt == ExifInterface.ORIENTATION_TRANSVERSE
         return RotateBitmapResult(bitmap, degrees, flipHorizontally, flipVertically)
     }
 
@@ -720,8 +724,8 @@ internal object BitmapUtils {
             options.inSampleSize = (
                 sampleMulti
                     * calculateInSampleSizeByReqestedSize(
-                        rect.width(), rect.height(), reqWidth, reqHeight
-                    )
+                    rect.width(), rect.height(), reqWidth, reqHeight
+                )
                 )
             val stream = context.contentResolver.openInputStream(uri)
             val decoder = BitmapRegionDecoder.newInstance(stream!!, false)

--- a/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageView.kt
@@ -711,9 +711,11 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
         val setBitmap: Bitmap?
         var degreesRotated = 0
         if (bitmap != null && exif != null) {
-            val result = BitmapUtils.rotateBitmapByExif(bitmap, exif)
+            val result = BitmapUtils.orientateBitmapByExif(bitmap, exif)
             setBitmap = result.bitmap
             degreesRotated = result.degrees
+            mFlipHorizontally = result.flipHorizontally
+            mFlipVertically = result.flipVertically
             mInitialDegreesRotated = result.degrees
         } else setBitmap = bitmap
 
@@ -866,6 +868,8 @@ class CropImageView @JvmOverloads constructor(context: Context, attrs: Attribute
         setProgressBarVisibility()
         if (result.error == null) {
             mInitialDegreesRotated = result.degreesRotated
+            mFlipHorizontally = result.flipHorizontally
+            mFlipVertically = result.flipVertically
             setBitmap(
                 result.bitmap,
                 0,


### PR DESCRIPTION
Closes #408 

## Bug
### Cause:
The BitMapUtils did not take all EXIF orientation values into account causing some images to show mirrored and rotated wrongly.

### Reproduce
GIVEN: An image with an EXIF value of 2, 4, 5 or 7
WHEN: Opening the image in the crop view
THEN: Images have the wrong orientation

### How the bug was solved:
Added the remaining of the `ORIENTATION` tags from the `ExifInterface` https://developer.android.com/reference/androidx/exifinterface/media/ExifInterface#TAG_ORIENTATION

**Before:**
|2|4|5|7|
|-|-|-|-|
| ![image](https://user-images.githubusercontent.com/56763273/179510030-a60f62dd-440b-4a65-af17-33fd3504d59a.png) | ![image](https://user-images.githubusercontent.com/56763273/179510048-e23946e2-d71f-416b-b97d-5b9b818dec1b.png) | ![image](https://user-images.githubusercontent.com/56763273/179510056-27114de0-91aa-44c3-be48-6ba6461bc14c.png) | ![image](https://user-images.githubusercontent.com/56763273/179510073-89395973-c564-42a8-ac88-65af3a72b2cf.png)



**After:**
|2|4|5|7|
|-|-|-|-|
| ![image](https://user-images.githubusercontent.com/56763273/179509759-08c5ce26-fbd4-4c53-a749-60e8e4c3f484.png) | ![image](https://user-images.githubusercontent.com/56763273/179509781-a4fc82d1-bbb2-4185-b1ee-c6938fb68440.png) | ![image](https://user-images.githubusercontent.com/56763273/179509797-b5ae5550-7a19-4369-becb-154c0acb9e97.png) | ![image](https://user-images.githubusercontent.com/56763273/179509808-ccfbabbe-48bd-4330-9456-2db439906e63.png)