### PR TITLE
Bugfix/427 back button doesnt work when activity launched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,7 +141,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - ENOENT (no such file or directory) [#99](https://github.com/CanHub/Android-Image-Cropper/issues/99)
-- `content://` instead of `file://` [#83](https://github.com/CanHub/Android-Image-Cropper/issues/83) [#84](https://github.com/CanHub/Android-Image-Cropper/issues/84)
+- `content://` instead of `file://` [#83](https://github.com/CanHub/Android-Image-Cropper/issues/83) [#84](https://github.com/CanHub/Android-Image-Cropper/issues/84) 
 
 ## [2.3.2-alpha] - 12/04/21
 ### Added
@@ -231,4 +231,3 @@ Versions `2.0.1` and `2.0.2` are similar, issues with jitpack.
 
 ## [1.0.0] - 21/11/20
 - Copy from previous repo [ArthurHub](https://github.com/ArthurHub/Android-Image-Cropper/)
-- 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,7 +143,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - ENOENT (no such file or directory) [#99](https://github.com/CanHub/Android-Image-Cropper/issues/99)
-- `content://` instead of `file://` [#83](https://github.com/CanHub/Android-Image-Cropper/issues/83) [#84](https://github.com/CanHub/Android-Image-Cropper/issues/84) 
+- `content://` instead of `file://` [#83](https://github.com/CanHub/Android-Image-Cropper/issues/83) [#84](https://github.com/CanHub/Android-Image-Cropper/issues/84)
 
 ## [2.3.2-alpha] - 12/04/21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added the option to set custom color to toolbar of CropImageActivity [#421](https://github.com/CanHub/Android-Image-Cropper/issues/421)
 - Added the option to set custom background color to activity of CropImageActivity [#421](https://github.com/CanHub/Android-Image-Cropper/issues/421)
 - Fixed accidentally swiping back on newer Android devices when trying to resize the crop window [#423](https://github.com/CanHub/Android-Image-Cropper/issues/423)
+- Fixed an issue on sample project where back button would not work when dialog is shown [#427](https://github.com/CanHub/Android-Image-Cropper/issues/427)
+- Fixed an issue on sample project where cancelling/going back would go to a screen with empty image [#427](https://github.com/CanHub/Android-Image-Cropper/issues/427)
 
 ## [4.3.1] - 20/07/2022
 ### Fix

--- a/cropper/src/main/java/com/canhub/cropper/CropImageActivity.kt
+++ b/cropper/src/main/java/com/canhub/cropper/CropImageActivity.kt
@@ -6,6 +6,7 @@ import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
+import android.view.KeyEvent
 import android.view.Menu
 import android.view.MenuItem
 import androidx.activity.result.contract.ActivityResultContracts
@@ -158,6 +159,12 @@ open class CropImageActivity :
     open fun showImageSourceDialog(openSource: (Source) -> Unit) {
         AlertDialog.Builder(this)
             .setCancelable(false)
+            .setOnKeyListener { _, keyCode, keyEvent ->
+                if (keyCode == KeyEvent.KEYCODE_BACK && keyEvent.action == KeyEvent.ACTION_UP) {
+                    onBackPressed()
+                }
+                true
+            }
             .setTitle(R.string.pick_image_chooser_title)
             .setItems(
                 arrayOf(

--- a/sample/src/main/java/com/canhub/cropper/sample/SampleCrop.kt
+++ b/sample/src/main/java/com/canhub/cropper/sample/SampleCrop.kt
@@ -59,6 +59,9 @@ internal class SampleCrop : Fragment() {
         }
     }
     private val customCropImage = registerForActivityResult(CropImageContract()) {
+        if (it is CropImage.CancelledResult) {
+            return@registerForActivityResult
+        }
         handleCropImageResult(it.uriContent.toString())
     }
 


### PR DESCRIPTION
close #427

## Bug:
Clicking back on a screen that shows an alert dialog with `Camera` and `Gallery` would do nothing.
### Cause:
The dialog is non dismiss-able so the back button is is ignored.

### Reproduce
Open the crop image screen which shows the non dismiss-able alert dialog with the options `Camera` and `Gallery`.
Click back and nothing happens.

### How the bug was solved:
Added an OnKeyListener to the non dismiss-able alert dialog to detect back key pressed. On back key detected the onBackPressed is triggered.

Also fixed the issue where on cancelling/pressing back when intending not to edit/crop the image it would open a screen with an empty image view.
