### PR TITLE
Correctly close resources in BitmapUtils.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added options to customize colors of toolbar back button, title and menu texts. [#437](https://github.com/CanHub/Android-Image-Cropper/issues/437)
 ### Fixed
 - Fixed and issue where setting toolbar color to white would do nothing. [#437](https://github.com/CanHub/Android-Image-Cropper/issues/437)
+- Correctly close resources in BitmapUtils
 
 ## [4.3.2] - 08/09/2022
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added options to customize colors of toolbar back button, title and menu texts. [#437](https://github.com/CanHub/Android-Image-Cropper/issues/437)
 ### Fixed
 - Fixed and issue where setting toolbar color to white would do nothing. [#437](https://github.com/CanHub/Android-Image-Cropper/issues/437)
-- Correctly close resources in BitmapUtils
+- Correctly close resources in BitmapUtils. [#440](https://github.com/CanHub/Android-Image-Cropper/issues/440)
 
 ## [4.3.2] - 08/09/2022
 ### Fixed

--- a/cropper/src/main/java/com/canhub/cropper/BitmapCroppingWorkerJob.kt
+++ b/cropper/src/main/java/com/canhub/cropper/BitmapCroppingWorkerJob.kt
@@ -149,7 +149,7 @@ class BitmapCroppingWorkerJob(
             this.sampleSize = sampleSize
         }
 
-        constructor(uri: Uri?, sampleSize: Int) {
+        constructor(uri: Uri, sampleSize: Int) {
             bitmap = null
             this.uri = uri
             error = null

--- a/cropper/src/main/java/com/canhub/cropper/BitmapUtils.kt
+++ b/cropper/src/main/java/com/canhub/cropper/BitmapUtils.kt
@@ -423,10 +423,10 @@ internal object BitmapUtils {
         compressFormat: CompressFormat,
         compressQuality: Int,
         customOutputUri: Uri?,
-    ): Uri? {
+    ): Uri {
         val newUri = customOutputUri ?: buildUri(context, compressFormat)
 
-        return context.contentResolver.openOutputStream(newUri!!, WRITE_AND_TRUNCATE).use {
+        return context.contentResolver.openOutputStream(newUri, WRITE_AND_TRUNCATE).use {
             bitmap.compress(compressFormat, compressQuality, it)
             newUri
         }
@@ -435,7 +435,7 @@ internal object BitmapUtils {
     private fun buildUri(
         context: Context,
         compressFormat: CompressFormat
-    ): Uri? =
+    ): Uri =
         try {
             val ext = when (compressFormat) {
                 CompressFormat.JPEG -> ".jpg"


### PR DESCRIPTION
```
             StrictMode  D  StrictMode policy violation: android.os.strictmode.LeakedClosableViolation: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resourc
                            e leaks.
                         D      at android.os.StrictMode$AndroidCloseGuardReporter.report(StrictMode.java:1986)
                         D      at dalvik.system.CloseGuard.warnIfOpen(CloseGuard.java:336)
                         D      at android.os.ParcelFileDescriptor.finalize(ParcelFileDescriptor.java:1069)
                         D      at java.lang.Daemons$FinalizerDaemon.doFinalize(Daemons.java:319)
                         D      at java.lang.Daemons$FinalizerDaemon.runInternal(Daemons.java:306)
                         D      at java.lang.Daemons$Daemon.run(Daemons.java:140)
                         D      at java.lang.Thread.run(Thread.java:1012)
                         D  Caused by: java.lang.Throwable: Explicit termination method 'close' not called
                         D      at dalvik.system.CloseGuard.openWithCallSite(CloseGuard.java:288)
                         D      at dalvik.system.CloseGuard.open(CloseGuard.java:257)
                         D      at android.os.ParcelFileDescriptor.<init>(ParcelFileDescriptor.java:206)
                         D      at android.os.ParcelFileDescriptor.<init>(ParcelFileDescriptor.java:189)
                         D      at android.os.ParcelFileDescriptor.open(ParcelFileDescriptor.java:232)
                         D      at androidx.core.content.FileProvider.openFile(FileProvider.java:632)
                         D      at android.content.ContentProvider.openAssetFile(ContentProvider.java:2073)
                         D      at android.content.ContentProvider.openTypedAssetFile(ContentProvider.java:2249)
                         D      at android.content.ContentProvider.openTypedAssetFile(ContentProvider.java:2316)
                         D      at android.content.ContentProvider$Transport.openTypedAssetFile(ContentProvider.java:561)
                         D      at android.content.ContentResolver.openTypedAssetFileDescriptor(ContentResolver.java:2027)
                         D      at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:1842)
                         D      at android.content.ContentResolver.openInputStream(ContentResolver.java:1518)
                         D      at com.canhub.cropper.BitmapUtils.decodeSampledBitmapRegion(BitmapUtils.kt:730)
                         D      at com.canhub.cropper.BitmapUtils.cropBitmap(BitmapUtils.kt:550)
                         D      at com.canhub.cropper.BitmapUtils.cropBitmap(BitmapUtils.kt:268)
                         D      at com.canhub.cropper.BitmapCroppingWorkerJob$start$1.invokeSuspend(BitmapCroppingWorkerJob.kt:48)
                         D      at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
                         D      at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
                         D      at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
                         D      at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:749)
                         D      at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
                         D      at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
```