### PR TITLE
Fix broken link

### DIFF
--- a/.documentation/FAQ.md
+++ b/.documentation/FAQ.md
@@ -8,8 +8,7 @@ Does your app theme has no action bar? If yes, you should add this to your manif
 ```
 
 ## Can I use this library in Java project?
-Yes! Check [Using the library in Java](
-.documentation/java_usage.md)
+Yes! Check [Using the library in Java](java_usage.md) 
 
 ## Bad class file error : class file has wrong version xx.0, should be yy.0
 It means your Java runtime version is different from your compiler version (javac).


### PR DESCRIPTION
We should do `java_usage.md` instead of `.documentation/java_usage.md` because the FAQ document is already in the `.documentation` folder.