### PR TITLE
Behavior Change: Always try to return resized bitmap in CropResult.

### DIFF
--- a/cropper/src/main/kotlin/com/canhub/cropper/BitmapCroppingWorkerJob.kt
+++ b/cropper/src/main/kotlin/com/canhub/cropper/BitmapCroppingWorkerJob.kt
@@ -94,9 +94,10 @@ internal class BitmapCroppingWorkerJob(
               compressQuality = saveCompressQuality,
               customOutputUri = customOutputUri,
             )
-            resizedBitmap.recycle()
+
             onPostExecute(
               Result(
+                bitmap = resizedBitmap,
                 uri = newUri,
                 sampleSize = bitmapSampled.sampleSize,
               ),


### PR DESCRIPTION
Fixes #355