### PR TITLE
Resource: Missing Translations added for korean / japanese

### DIFF
--- a/cropper/src/main/res/values-ja/strings.xml
+++ b/cropper/src/main/res/values-ja/strings.xml
@@ -7,4 +7,6 @@
   <string name="ic_flip_24_horizontally">左右反転</string>
   <string name="ic_flip_24_vertically">上下反転</string>
   <string name="pick_image_chooser_title">画像を選択</string>
+  <string name="pick_image_camera">撮影</string>
+  <string name="pick_image_gallery">アルバム</string>
 </resources>

--- a/cropper/src/main/res/values-ko/strings.xml
+++ b/cropper/src/main/res/values-ko/strings.xml
@@ -7,4 +7,6 @@
   <string name="ic_flip_24_horizontally">좌우반전</string>
   <string name="ic_flip_24_vertically">상하반전</string>
   <string name="pick_image_chooser_title">이미지 선택</string>
+  <string name="pick_image_camera">촬영</string>
+  <string name="pick_image_gallery">앨범</string>
 </resources>


### PR DESCRIPTION
Missing Translations for `pick_image_camera` && `pick_image_gallery` added for below languages.
- korean
- japanese
> related issue : #551 