### PR TITLE
Fixed bug when changing toolbar text color

### DIFF
--- a/cropper/src/main/kotlin/com/canhub/cropper/CropImageActivity.kt
+++ b/cropper/src/main/kotlin/com/canhub/cropper/CropImageActivity.kt
@@ -450,7 +450,7 @@ open class CropImageActivity : AppCompatActivity(), OnSetImageUriCompleteListene
    * Update the color of a specific menu item to the given color.
    */
   open fun updateMenuItemTextColor(menu: Menu, itemId: Int, color: Int) {
-    val menuItem = menu.findItem(itemId)
+    val menuItem = menu.findItem(itemId) ?: return
     val menuTitle = menuItem.title
     if (menuTitle?.isNotBlank() == true) {
       try {


### PR DESCRIPTION
I find an issue that happens in order to change the `activityMenuTextColor` color and if you disabled other buttons from the toolbar like the flip menu, you will get a crash because the menu is null.

This code snippet will cause a crash if you use it:
``` kotlin
CropImageOptions().apply {
    allowFlipping = false
    activityMenuTextColor = getColor(R.color.purple)
}
```


## Crash log

``` java
java.lang.NullPointerException: Attempt to invoke interface method 'java.lang.CharSequence android.view.MenuItem.getTitle()' on a null object reference
   at com.canhub.cropper.CropImageActivity.updateMenuItemTextColor(CropImageActivity.kt:454)
   at com.canhub.cropper.CropImageActivity.onCreateOptionsMenu(CropImageActivity.kt:288)
   at android.app.Activity.onCreatePanelMenu(Activity.java:3373)
   at androidx.activity.ComponentActivity.onCreatePanelMenu(ComponentActivity.java:521)
   at androidx.fragment.app.FragmentActivity.onCreatePanelMenu(FragmentActivity.java:287)
   at androidx.appcompat.view.WindowCallbackWrapper.onCreatePanelMenu(WindowCallbackWrapper.java:95)
   at androidx.appcompat.app.AppCompatDelegateImpl$AppCompatWindowCallback.onCreatePanelMenu(AppCompatDelegateImpl.java:3122)
   at androidx.appcompat.app.AppCompatDelegateImpl.preparePanel(AppCompatDelegateImpl.java:1913)
   at androidx.appcompat.app.AppCompatDelegateImpl.doInvalidatePanelMenu(AppCompatDelegateImpl.java:2194)
   at androidx.appcompat.app.AppCompatDelegateImpl$2.run(AppCompatDelegateImpl.java:276)
   at android.os.Handler.handleCallback(Handler.java:789)
   at android.os.Handler.dispatchMessage(Handler.java:98)
   at android.os.Looper.loop(Looper.java:164)
   at android.app.ActivityThread.main(ActivityThread.java:6541)
   at java.lang.reflect.Method.invoke(Native Method)
   at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:767)
```