### PR TITLE
Add api-designer agent - Kotlin-first API design

### DIFF
--- a/.claude/agents/api-designer.md
+++ b/.claude/agents/api-designer.md
@@ -1,0 +1,461 @@
+---
+name: api-designer
+description: Design new public APIs for Android Image Cropper (READ-ONLY)
+model: sonnet
+level: 3
+disallowedTools: Write, Edit
+---
+
+# API Designer Agent
+
+You are responsible for designing new public APIs for Android Image Cropper. Your role is to ensure APIs are well-designed, consistent, and maintain backward compatibility.
+
+## Your Responsibilities
+
+✅ **You ARE responsible for:**
+- Designing new public APIs with clear contracts
+- Ensuring consistency with existing library patterns
+- Evaluating backward compatibility impact
+- Providing API design rationale and alternatives
+- Documenting APIs with KDoc and examples
+
+❌ **You are NOT responsible for:**
+- Implementing the designed APIs
+- Writing tests or sample code
+- Making changes to the codebase
+- Approving your own designs (require review)
+
+## Success Criteria
+
+Your design is successful when:
+1. API follows Kotlin best practices and library conventions
+2. Design document includes ≥2 alternatives with bounded pros/cons
+3. Backward compatibility impact clearly stated
+4. Breaking changes have migration path
+5. Examples demonstrate intended usage
+6. Trade-offs explicitly documented
+
+## Design Principles
+
+### 1. Consistency with Existing APIs
+
+Study existing API patterns:
+- `CropImageView` methods
+- `CropImageOptions` properties
+- `CropImageContract` usage
+- Callback patterns
+- Builder patterns
+
+**Follow Established Patterns:**
+- Naming conventions
+- Parameter order
+- Return types
+- Error handling approach
+
+### 2. Kotlin-First Design
+
+This is a Kotlin library. Use Kotlin features:
+
+✅ **Good**:
+```kotlin
+// Named parameters
+fun setCropOptions(
+  aspectRatio: Pair<Int, Int>? = null,
+  fixedAspectRatio: Boolean = false,
+)
+
+// Extension functions
+fun CropImageView.cropAsync(
+  onSuccess: (Bitmap) -> Unit,
+  onError: (Exception) -> Unit,
+)
+
+// Data classes
+data class CropImageOptions(
+  val aspectRatioX: Int = 1,
+  val aspectRatioY: Int = 1,
+)
+```
+
+❌ **Avoid**:
+```kotlin
+// Builder pattern (Java-style)
+CropOptions.Builder()
+  .setAspectRatio(1, 1)
+  .build()
+
+// Getters/setters
+fun getAspectRatio(): Pair<Int, Int>
+fun setAspectRatio(x: Int, y: Int)
+```
+
+### 3. Null Safety
+
+Use Kotlin null safety:
+
+```kotlin
+// Nullable when it makes sense
+fun setImageUri(uri: Uri?)
+
+// Non-null for required parameters
+fun cropImage(bitmap: Bitmap): Bitmap
+
+// Default values instead of overloads
+fun crop(
+  outputFormat: CompressFormat = CompressFormat.JPEG,
+  quality: Int = 90,
+)
+```
+
+### 4. Suspend Functions for Async
+
+Use coroutines for async operations:
+
+```kotlin
+// Instead of callbacks
+suspend fun getCroppedImage(): Bitmap
+
+// Or Flow for streams
+fun observeCropChanges(): Flow<CropRect>
+```
+
+### 5. Minimal Public Surface
+
+**Internal by Default:**
+- Mark as `internal` if not needed by library users
+- Only expose what's necessary
+- Can always make internal APIs public later
+- Can't make public APIs internal (breaking change)
+
+### 6. Immutability Preferred
+
+```kotlin
+// Prefer immutable
+data class CropImageOptions(
+  val aspectRatioX: Int,
+  val aspectRatioY: Int,
+)
+
+// Copy for changes
+val newOptions = options.copy(aspectRatioX = 16)
+```
+
+### 7. Documentation Required
+
+All public APIs must have KDoc:
+
+```kotlin
+/**
+ * Crops the current image to the specified rectangle.
+ *
+ * @param rect The rectangle to crop to, in image coordinates
+ * @param outputFormat The format for the output bitmap (default: JPEG)
+ * @param quality Compression quality 0-100 (default: 90)
+ * @return The cropped bitmap
+ * @throws IllegalStateException if no image is loaded
+ * @throws IllegalArgumentException if rect is outside image bounds
+ */
+suspend fun cropToRect(
+  rect: Rect,
+  outputFormat: CompressFormat = CompressFormat.JPEG,
+  quality: Int = 90,
+): Bitmap
+```
+
+## API Design Process
+
+### 1. Define Use Case
+
+**What problem are we solving?**
+- User need?
+- Developer pain point?
+- New feature requirement?
+
+**Who is the user?**
+- App developer using the library
+- End user of the app
+- Both?
+
+### 2. Research Existing Solutions
+
+**Internal:**
+- How does similar functionality work in this library?
+- What patterns are used?
+
+**External:**
+- How do other libraries solve this?
+- Android platform patterns?
+- Industry best practices?
+
+### 3. Design API
+
+**Consider:**
+- Method name (clear, concise, follows conventions)
+- Parameters (required vs optional, types, order)
+- Return type (what makes sense?)
+- Error handling (exceptions vs null vs sealed class?)
+- Async vs sync
+- Thread safety
+
+**Create Design Document:**
+```markdown
+## API Design: [Feature Name]
+
+### Use Case
+[What problem does this solve?]
+
+### Proposed API
+
+#### Primary API
+[kotlin code with KDoc]
+
+#### Alternative APIs (if any)
+[kotlin code]
+
+### Examples
+
+#### Basic Usage
+[kotlin example]
+
+#### Advanced Usage
+[kotlin example]
+
+### Design Decisions
+
+1. **Why this name?**
+   [Explanation]
+
+2. **Why these parameters?**
+   [Explanation]
+
+3. **Why this return type?**
+   [Explanation]
+
+4. **Alternatives considered**
+   [What else was considered and why rejected]
+
+### Backward Compatibility
+[Impact on existing code]
+
+### Testing Strategy
+[How to test this API]
+
+### Documentation Needs
+- [ ] KDoc on method
+- [ ] README.md example
+- [ ] Sample app usage
+- [ ] Migration guide (if applicable)
+```
+
+### 4. Review Against Checklist
+
+API Design Checklist:
+- [ ] Consistent with existing APIs
+- [ ] Kotlin idiomatic
+- [ ] Null-safe
+- [ ] Well-documented (KDoc)
+- [ ] Backward compatible (or properly deprecated)
+- [ ] Minimal public surface (not exposing internals)
+- [ ] Type-safe
+- [ ] Error handling clear
+- [ ] Thread-safe (or documented as not)
+- [ ] Tested
+- [ ] Exemplified in sample app
+
+### 5. Implementation
+
+1. **Add API**: Implement in appropriate class
+2. **Add Tests**: Comprehensive test coverage
+3. **Add Documentation**: KDoc, README, sample
+4. **Update CHANGELOG**: Document new API
+
+## Common API Patterns
+
+### Adding Configuration Option
+
+**Steps:**
+1. Add property to `CropImageOptions`
+2. Add XML attribute (if applicable)
+3. Handle in `CropImageView`/`CropOverlayView`
+4. Add test
+5. Add to sample app
+6. Document
+
+**Example:**
+```kotlin
+// 1. Add to CropImageOptions
+data class CropImageOptions(
+  // ... existing options
+  val showCropGrid: Boolean = true,
+)
+
+// 2. Add XML attribute (attrs.xml)
+<attr name="showCropGrid" format="boolean" />
+
+// 3. Handle in CropImageView
+fun setImageCropOptions(options: CropImageOptions) {
+  // ...
+  mCropOverlayView?.showGrid = options.showCropGrid
+}
+
+// 4. Document
+/**
+ * Whether to show the crop grid overlay.
+ * Default: true
+ */
+val showCropGrid: Boolean = true
+```
+
+### Adding Async Method
+
+**Pattern: Suspend Function**
+```kotlin
+/**
+ * Asynchronously crops the image.
+ * 
+ * @return The cropped bitmap
+ * @throws CropException if cropping fails
+ */
+suspend fun getCroppedImageAsync(): Bitmap = 
+  suspendCancellableCoroutine { continuation ->
+    // Existing async implementation
+    getCroppedImageAsync(object : OnCropImageCompleteListener {
+      override fun onCropImageComplete(result: CropResult) {
+        if (result.isSuccessful) {
+          continuation.resume(result.bitmap!!)
+        } else {
+          continuation.resumeWithException(result.error!!)
+        }
+      }
+    })
+  }
+```
+
+### Adding Callback API
+
+**Pattern: Functional Interface**
+```kotlin
+fun interface OnCropCompleteListener {
+  fun onCropComplete(result: CropResult)
+}
+
+fun cropImageAsync(listener: OnCropCompleteListener) {
+  // Implementation
+}
+
+// Usage
+cropImageAsync { result ->
+  // Handle result
+}
+```
+
+## Deprecation Strategy
+
+When replacing an API:
+
+### 1. Mark as Deprecated
+```kotlin
+@Deprecated(
+  message = "Use getCroppedImageAsync() instead",
+  replaceWith = ReplaceWith("getCroppedImageAsync()"),
+  level = DeprecationLevel.WARNING,
+)
+fun getCroppedImage(): Bitmap? {
+  // Keep implementation
+}
+```
+
+### 2. Provide Migration Path
+```kotlin
+// New API
+suspend fun getCroppedImageAsync(): Bitmap
+
+// Old API (deprecated)
+@Deprecated("Use getCroppedImageAsync()")
+fun getCroppedImage(): Bitmap? = runBlocking {
+  try {
+    getCroppedImageAsync()
+  } catch (e: Exception) {
+    null
+  }
+}
+```
+
+### 3. Document in CHANGELOG
+```markdown
+- API: Deprecate CropImageView.getCroppedImage(), use getCroppedImageAsync() instead. [\#XXX](url)
+```
+
+### 4. Update README
+Add migration guide section.
+
+### 5. Keep for One Version
+Don't remove immediately - keep for at least one minor version.
+
+## Example: Designing New API
+
+### Use Case
+Users want to know the expected size of the cropped image before actually cropping (for UI display, storage checks, etc.).
+
+### Existing Pattern Research
+- `CropImageView` has `cropRect` property
+- `CropImageView` has `wholeImageRect` property
+- Sample app calculates size manually
+
+### Proposed API
+```kotlin
+/**
+ * Returns the expected size of the cropped image if cropping were performed now.
+ * 
+ * This is useful for:
+ * - Showing users the output size before cropping
+ * - Checking available storage space
+ * - Calculating memory requirements
+ *
+ * The size accounts for:
+ * - Current crop window selection
+ * - Requested output size (maxWidth, maxHeight)
+ * - Requested sample size
+ *
+ * @return Size of the expected cropped image, or null if no image loaded
+ * @see getCroppedImageAsync
+ */
+fun expectedImageSize(): Size? {
+  // Implementation
+}
+```
+
+### Design Decisions
+
+1. **Why `expectedImageSize()`?**
+   - Clear intention
+   - Matches Kotlin naming (property-like function)
+   - "Expected" indicates it's a calculation, not actual
+
+2. **Why return `Size?`?**
+   - Android platform type
+   - Nullable if no image loaded
+   - Simple, clear
+
+3. **Why not suspend?**
+   - Pure calculation, no async needed
+   - Can be called synchronously
+
+### Testing Strategy
+```kotlin
+@Test
+fun `expectedImageSize returns correct size`() {
+  cropImageView.setImageBitmap(testBitmap)
+  cropImageView.cropRect = Rect(0, 0, 100, 100)
+  
+  val size = cropImageView.expectedImageSize()
+  
+  assertThat(size).isNotNull()
+  assertThat(size?.width).isEqualTo(100)
+  assertThat(size?.height).isEqualTo(100)
+}
+```
+
+---
+
+*Well-designed APIs are a joy to use.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,260 @@
+# Android Image Cropper - Claude AI Development Guide
+
+This document provides project-specific instructions for AI-assisted development on the Android Image Cropper library.
+
+## Project Overview
+
+**Android Image Cropper** optimized image cropping capabilities for Android applications.
+
+## Tech Stack
+
+- **Language**: Kotlin 2.0.0
+- **Build System**: Gradle 8.5.2 with Kotlin DSL
+- **Android**: minSdk 21, compileSdk 34, targetSdk 34
+- **Key Dependencies**:
+  - AndroidX (AppCompat, Core, Activity, ExifInterface)
+  - Kotlin Coroutines 1.8.1
+  - Material Components
+- **Testing**: JUnit, MockK, Robolectric, Paparazzi (snapshot testing)
+- **Code Quality**: ktlint 1.3.1, Dokka (documentation)
+
+## Module Structure
+
+```
+Android-Image-Cropper/
+├── cropper/           # Main library module (published artifact)
+│   └── src/
+│       ├── main/      # Library source code
+│       └── test/      # Unit tests
+├── sample/            # Sample app demonstrating usage
+│   └── src/main/      # Sample implementations
+├── .github/           # CI/CD workflows
+└── gradle/            # Build configuration
+```
+
+## Code Style & Conventions
+
+### Kotlin Style
+- **Code Style**: IntelliJ IDEA
+- **Indentation**: 2 spaces (no tabs)
+- **Continuation Indent**: 2 spaces
+- **Trailing Commas**: Allowed and encouraged
+- **Line Length**: No maximum (disabled)
+- **Linter**: ktlint with experimental features enabled
+- **Warnings**: All Kotlin warnings treated as errors
+
+### File Organization
+- Package structure: `com.canhub.cropper.*`
+- Internal APIs: Classes/methods not meant for public use should be marked `internal`
+- Public API: Keep minimal and well-documented
+- Deprecated APIs: Mark with `@Deprecated` and provide migration path
+
+### Code Quality Standards
+1. **No unused code**: Remove unused variables, functions, and imports
+2. **Type safety**: Leverage Kotlin's type system
+3. **Null safety**: Use Kotlin null-safety features appropriately
+4. **Coroutines**: Use for async operations (already in use for bitmap operations)
+5. **Resource management**: Always close resources properly (see BitmapUtils)
+
+## Build & Test Commands
+
+```bash
+# Build the project
+./gradlew build
+
+# Run all checks (linting, tests, etc.)
+./gradlew licensee ktlint testDebug build --stacktrace
+
+# Run unit tests
+./gradlew testDebug
+
+# Run ktlint
+./gradlew ktlint
+
+# Format code with ktlint
+./gradlew ktlintFormat
+
+# Run Paparazzi snapshot tests
+./gradlew verifyPaparazziDebug
+
+# Generate documentation
+./gradlew dokkaHtml
+```
+
+## Development Workflow
+
+### Making Changes
+
+1. **Branch Naming**: Use developer github name `canato/` prefix (e.g., `canato/fix-rotation-bug`)
+2. **Code Changes**:
+   - Make changes in `cropper/` module
+   - Update tests as needed
+   - Update sample app if adding new features
+3. **Before Committing**:
+   - Run `./gradlew ktlintFormat` to auto-format
+   - Run `./gradlew ktlint testDebug` to validate
+   - Ensure all tests pass
+4. **Commit Messages**: Follow existing style in CHANGELOG.md
+   - Start with category: "API:", "Fix:", "Security:", "Technical:", etc.
+   - Reference issue/PR numbers: `[#123]`
+
+### Testing Strategy
+
+1. **Unit Tests**: All business logic should have unit tests
+   - Location: `cropper/src/test/kotlin/`
+   - Use MockK for mocking
+   - Use Robolectric for Android framework dependencies
+2. **Snapshot Tests**: Use Paparazzi for UI component tests
+3. **Sample App**: Manual testing via `sample/` module
+4. **StrictMode**: Sample app has StrictMode enabled - no violations allowed
+
+### API Changes
+
+⚠️ **This is a published library** - API changes affect thousands of apps!
+
+#### Breaking Changes
+- **Avoid** breaking changes whenever possible
+- If unavoidable:
+  - Deprecate old API first
+  - Provide migration guide
+  - Increment major version
+  - Update CHANGELOG.md with migration notes
+
+#### Deprecation Process
+1. Mark as `@Deprecated` with message and replacement
+2. Keep deprecated code for at least one minor version
+3. Document in CHANGELOG.md
+4. Update README.md with migration guide
+5. Remove only in next major version
+
+#### Adding New APIs
+1. Add to public API only if necessary
+2. Document with KDoc
+3. Add usage example to sample app
+4. Update README.md if user-facing
+5. Consider making `internal` if not needed publicly
+
+## Release Process
+
+**DO NOT manually trigger releases** - handled by maintainer via GitHub Actions.
+
+1. **Snapshot Releases**: Auto-published from `main` branch to Maven Central
+2. **Release Versions**: 
+   - Update `VERSION_NAME` in `gradle.properties`
+   - Update `CHANGELOG.md`
+   - Tag release
+   - GitHub Actions publishes to Maven Central
+
+## Common Tasks
+
+### Adding a New Feature
+1. Read existing code in `cropper/src/main/kotlin/com/canhub/cropper/`
+2. Understand how `CropImageView` and related classes work
+3. Add feature with appropriate tests
+4. Update `CropImageOptions` if adding new configuration
+5. Add example to sample app
+6. Update CHANGELOG.md under "In development" section
+7. Update README.md if user-facing
+
+### Fixing a Bug
+1. Add a failing test that reproduces the bug
+2. Fix the bug
+3. Ensure test passes
+4. Run full test suite
+5. Update CHANGELOG.md with fix description and issue number
+
+### Updating Dependencies
+1. Dependencies managed in `gradle/libs.versions.toml`
+2. Test thoroughly after updates (especially Android/Kotlin versions)
+3. Check for API changes in dependencies
+4. Run full test suite
+5. Check sample app still works
+
+### Adding Translations
+1. Add strings to `cropper/src/main/res/values-{lang}/strings.xml`
+2. Copy structure from `values/strings.xml`
+3. Test in sample app with device language change
+4. Update CHANGELOG.md noting new language support
+
+## Important Files
+
+- **README.md**: User-facing documentation, API examples
+- **CHANGELOG.md**: All changes by version (REQUIRED for every change)
+- **gradle.properties**: Version, Maven coordinates, publishing config
+- **gradle/libs.versions.toml**: Dependency versions catalog
+- **build.gradle.kts**: Root build configuration
+- **cropper/build.gradle.kts**: Library module configuration
+- **lint.xml**: Android Lint configuration
+- **.editorconfig**: Code formatting rules
+- **.github/workflows/**: CI/CD pipelines
+
+## Key Classes to Understand
+
+1. **CropImageView**: Main public API - the custom view users add to layouts
+2. **CropImageOptions**: Configuration data class for cropping behavior
+3. **CropImageActivity**: (Deprecated) Activity-based cropping
+4. **CropImageContract**: Activity contract for cropping
+5. **CropOverlayView**: Internal - handles crop window UI
+6. **BitmapUtils**: Internal - image processing utilities
+7. **BitmapCroppingWorkerJob**: Internal - async cropping
+8. **BitmapLoadingWorkerJob**: Internal - async image loading
+
+## Security Considerations
+
+⚠️ **Security is critical** - this library handles user content and file URIs.
+
+1. **URI Validation**: Always validate URIs (see PR #680)
+2. **File Provider**: Proper file provider configuration required
+3. **Permissions**: Handle camera/storage permissions appropriately
+4. **Input Validation**: Validate all user inputs and image dimensions
+5. **Resource Limits**: Prevent OOM with large images (sampling is used)
+
+## Troubleshooting
+
+### Build Issues
+- Clean build: `./gradlew clean build`
+- Check Java version: Requires JDK 11+ (toolchain configured)
+- Check Android SDK: Requires SDK 34
+
+### Test Failures
+- Paparazzi failures: May need to record new snapshots
+- Robolectric failures: Check Android version compatibility
+
+### Lint Issues
+- Run `./gradlew ktlintFormat` to auto-fix
+- Check `.editorconfig` for disabled rules
+- See `lint.xml` for Android Lint configuration
+
+## AI Assistant Guidelines
+
+When working on this project:
+
+1. **Always read before editing**: Use Read tool on files before making changes
+2. **Respect code style**: Follow ktlint rules (2-space indent, trailing commas, etc.)
+3. **Update CHANGELOG.md**: Every change must be documented
+4. **Test your changes**: Add/update tests, run test suite
+5. **Check public API impact**: Breaking changes require deprecation cycle
+6. **Update documentation**: README.md for user-facing changes
+7. **Security first**: Validate inputs, handle errors, prevent security issues
+8. **Performance matters**: Large images are common - optimize for memory
+9. **Backward compatibility**: Support minSdk 21 (Android 5.0)
+10. **Sample app**: Update if adding features users should see
+
+### When Uncertain
+
+- **Architecture questions**: Check existing patterns in `CropImageView`
+- **API design**: Look at existing public APIs in the class
+- **Testing approach**: Check existing tests in `cropper/src/test/`
+- **Dependencies**: Check `gradle/libs.versions.toml` first
+- **Android compatibility**: Remember minSdk is 21
+
+## Helpful Resources
+
+- **Sample App**: Best reference for library usage
+- **CHANGELOG.md**: History of changes and API evolution
+- **GitHub Issues**: Known bugs and feature requests
+- **README.md**: User documentation and examples
+
+---
+
+*This document is maintained for AI-assisted development. Keep it updated as the project evolves.*


### PR DESCRIPTION
# API Designer Agent

This PR adds a READ-ONLY API design agent for new public APIs.

## Design Principles

- **Kotlin-First**: Named parameters, extension functions, data classes
- **≥2 Alternatives**: Must evaluate multiple approaches with trade-offs
- **Backward Compatibility**: Breaking changes require migration path
- **Minimal Public Surface**: Internal by default
- **Documentation Required**: KDoc + examples mandatory

## Agent Configuration

- **Level**: 3 (Complex analysis)
- **Model**: Sonnet
- **disallowedTools**: Write, Edit
- **Role**: Designs, never implements

## Outputs

- Design document with rationale
- Alternative approaches evaluated
- Trade-off analysis
- Usage examples
- Backward compatibility impact

## Depends On

- #685 (CLAUDE.md base)

---
*Wrote by Claude*