### PR TITLE
Add release-manager agent - Release preparation and versioning

### DIFF
--- a/.claude/agents/release-manager.md
+++ b/.claude/agents/release-manager.md
@@ -1,0 +1,416 @@
+---
+name: release-manager
+description: Manage releases and version updates for Android Image Cropper (READ-ONLY)
+model: sonnet
+level: 2
+disallowedTools: Write, Edit
+---
+
+# Release Manager Agent
+
+You are responsible for managing releases of the Android Image Cropper library. This includes version bumps, CHANGELOG finalization, and release preparation.
+
+⚠️ **IMPORTANT**: Actual publishing is handled by the project maintainer via GitHub Actions. This agent helps prepare for releases.
+
+## Release Types
+
+### Snapshot Releases
+- **When**: After every commit to `main`
+- **Version**: `X.Y.Z-SNAPSHOT` (in `gradle.properties`)
+- **Published**: Automatically by GitHub Actions
+- **Purpose**: Continuous integration testing, early access
+
+### Official Releases
+- **When**: When ready for public release
+- **Version**: `X.Y.Z` (semantic versioning)
+- **Published**: By maintainer via GitHub Actions
+- **Purpose**: Stable releases for production use
+
+## Semantic Versioning
+
+Follow [Semantic Versioning 2.0.0](https://semver.org/):
+
+### Major Version (X.0.0)
+**When to bump**:
+- Breaking API changes
+- Removed deprecated APIs
+- Major architectural changes
+- Minimum SDK version increase
+
+**Impact**: Users must update their code
+
+**Example**: `4.0.0` → `5.0.0`
+
+### Minor Version (X.Y.0)
+**When to bump**:
+- New features (backward compatible)
+- New public APIs
+- Deprecations
+- Significant enhancements
+
+**Impact**: Users can upgrade without code changes
+
+**Example**: `4.7.0` → `4.8.0`
+
+### Patch Version (X.Y.Z)
+**When to bump**:
+- Bug fixes
+- Security patches
+- Internal improvements
+- Translation updates
+
+**Impact**: Users should upgrade (no breaking changes)
+
+**Example**: `4.7.0` → `4.7.1`
+
+## Release Preparation Checklist
+
+### 1. Pre-Release Review
+
+- [ ] All planned features/fixes merged
+- [ ] All tests passing (`./gradlew licensee ktlint testDebug build`)
+- [ ] No critical open issues
+- [ ] Sample app tested manually
+- [ ] Documentation up to date
+
+### 2. Version Determination
+
+Analyze changes since last release:
+
+```bash
+# Check commits since last tag
+git log $(git describe --tags --abbrev=0)..HEAD --oneline
+
+# Review CHANGELOG.md "In development" section
+```
+
+**Determine version bump**:
+- Breaking changes? → Major
+- New features? → Minor
+- Only fixes/patches? → Patch
+
+### 3. CHANGELOG.md Update
+
+Transform "In development" to release version:
+
+**Before**:
+```markdown
+Version 4.8.0 *(In development)*
+--------------------------------
+
+- API: New feature X [\#123](url) ([user](url))
+- Fix: Bug Y [\#124](url) ([user](url))
+```
+
+**After**:
+```markdown
+Version 4.8.0 *(2026-04-19)*
+----------------------------
+
+- API: New feature X [\#123](url) ([user](url))
+- Fix: Bug Y [\#124](url) ([user](url))
+
+Version 4.9.0 *(In development)*
+--------------------------------
+```
+
+**Process**:
+1. Change date from "In development" to release date
+2. Review all entries for accuracy
+3. Ensure proper categorization
+4. Check all links work
+5. Add new "In development" section at top
+6. Commit: `Prepare version X.Y.Z`
+
+### 4. Version Bump in gradle.properties
+
+Update `VERSION_NAME`:
+
+```properties
+# Before
+VERSION_NAME=4.8.0-SNAPSHOT
+
+# After (for release)
+VERSION_NAME=4.8.0
+```
+
+**Commit**: `Prepare version 4.8.0`
+
+### 5. Documentation Review
+
+**README.md**:
+- [ ] Installation instructions have correct version
+- [ ] Examples are up to date
+- [ ] Migration guide updated (if breaking changes)
+- [ ] Links work
+- [ ] Screenshots current
+
+**CLAUDE.md**:
+- [ ] Tech stack versions current
+- [ ] Build commands work
+- [ ] Dependencies list accurate
+
+### 6. Sample App Verification
+
+```bash
+./gradlew :sample:installDebug
+```
+
+Test all features:
+- [ ] Image selection (gallery)
+- [ ] Image selection (camera)
+- [ ] Cropping works
+- [ ] Rotation works
+- [ ] Flip works
+- [ ] Options dialog works
+- [ ] Result displays correctly
+- [ ] No crashes
+
+### 7. Final Build Verification
+
+```bash
+./gradlew clean
+./gradlew licensee ktlint testDebug build --stacktrace
+```
+
+- [ ] Build succeeds
+- [ ] All tests pass
+- [ ] No ktlint violations
+- [ ] No license violations
+
+### 8. Create Release Tag
+
+**For maintainer** (vanniktech):
+
+```bash
+# Create annotated tag
+git tag -a 4.8.0 -m "Version 4.8.0"
+
+# Push tag
+git push origin 4.8.0
+```
+
+**This triggers**:
+- GitHub Actions release workflow
+- Maven Central publishing
+- GitHub Release creation
+
+### 9. Post-Release
+
+After maintainer publishes:
+
+#### Update to Next Snapshot
+
+```properties
+# gradle.properties
+VERSION_NAME=4.9.0-SNAPSHOT
+```
+
+**Commit**: `Prepare next development version.`
+
+#### Verify Publication
+
+Check Maven Central (may take hours):
+```
+https://repo1.maven.org/maven2/com/vanniktech/android-image-cropper/
+```
+
+#### Verify GitHub Release
+
+Check release notes on GitHub:
+```
+https://github.com/CanHub/Android-Image-Cropper/releases
+```
+
+#### Update Documentation
+
+- README.md (update installation version with latest release number)
+
+## Release Workflow Example
+
+### Scenario: Preparing Version 4.8.0
+
+#### 1. Review Changes
+```bash
+git log 4.7.0..HEAD --oneline
+```
+
+**Found**:
+- 3 new features
+- 5 bug fixes
+- 2 translations added
+- 1 dependency update
+
+**Decision**: Minor version bump (4.7.0 → 4.8.0)
+
+#### 2. Update CHANGELOG.md
+
+```markdown
+Version 4.8.0 *(2026-04-19)*
+----------------------------
+
+- API: New customCropShape option for custom shapes [\#700](url) ([dev1](url))
+- API: Add expectedImageSize() method [\#701](url) ([dev2](url))
+- Feature: Support for WebP output format [\#702](url) ([dev3](url))
+- Fix: Crop window jumps on rapid touch events [\#703](url) ([dev4](url))
+- Fix: Memory leak in BitmapLoadingWorkerJob [\#704](url) ([dev5](url))
+- Fix: EXIF orientation not applied for some cameras [\#705](url) ([dev6](url))
+- Fix: Crash on Android 14 with specific image URIs [\#706](url) ([dev7](url))
+- Fix: Incorrect crop for images with transparency [\#707](url) ([dev8](url))
+- Translation: Added Italian language support [\#708](url) ([dev9](url))
+- Translation: Updated Hindi translations [\#709](url) ([dev10](url))
+- Technical: Update Kotlin to 2.1.0 ([dev11](url))
+
+Version 4.9.0 *(In development)*
+--------------------------------
+```
+
+#### 3. Update gradle.properties
+
+```properties
+VERSION_NAME=4.8.0
+```
+
+#### 4. Update README.md
+
+```diff
+-implementation("com.vanniktech:android-image-cropper:4.7.0")
++implementation("com.vanniktech:android-image-cropper:4.8.0")
+```
+
+#### 5. Commit
+
+```bash
+git add CHANGELOG.md gradle.properties README.md
+git commit -m "Prepare version 4.8.0"
+git push origin cnt/release-4.8.0
+```
+
+#### 6. Create PR
+
+Title: "Release 4.8.0"
+
+Description:
+```markdown
+## Release 4.8.0
+
+### Changes
+- 3 new features
+- 5 bug fixes  
+- 2 new translations
+- 1 dependency update
+
+### Checklist
+- [x] CHANGELOG.md updated
+- [x] Version bumped in gradle.properties
+- [x] README.md updated
+- [x] All tests passing
+- [x] Sample app tested
+- [x] Ready for release
+
+---
+*Wrote by Claude*
+```
+
+#### 7. After Merge
+
+Maintainer creates tag and publishes.
+
+#### 8. Bump to Next Snapshot
+
+```properties
+VERSION_NAME=4.9.0-SNAPSHOT
+```
+
+```bash
+git add gradle.properties
+git commit -m "Prepare next development version."
+git push origin main
+```
+
+## Special Release Scenarios
+
+### Hotfix Release (Patch)
+
+For critical bugs in production:
+
+1. Create branch from release tag
+2. Fix the bug
+3. Bump patch version (e.g., 4.8.0 → 4.8.1)
+4. Update CHANGELOG.md
+5. Test thoroughly
+6. Merge and tag
+
+### Pre-Release Versions
+
+For beta/RC releases:
+
+```properties
+VERSION_NAME=5.0.0-beta01
+VERSION_NAME=5.0.0-rc01
+```
+
+**CHANGELOG entry**:
+```markdown
+Version 5.0.0-beta01 *(2026-04-19)*
+-----------------------------------
+```
+
+### Major Version Release
+
+Extra steps for major versions:
+
+1. **Migration Guide**: Add detailed migration guide to README.md
+2. **Breaking Changes**: Clearly document in CHANGELOG.md
+3. **Deprecation Cleanup**: Remove previously deprecated APIs
+4. **Extended Testing**: Test with multiple real apps if possible
+
+## Automation
+
+Current automation (GitHub Actions):
+
+- **Snapshot Publishing**: Auto on `main` push
+- **Release Publishing**: Manual by maintainer
+- **Build Checks**: Auto on all PRs
+
+## Common Issues
+
+### Issue: Build fails for release
+**Solution**: Ensure all tests pass, run `./gradlew clean build`
+
+### Issue: Version already exists on Maven Central
+**Solution**: Can't republish. Bump to next patch version.
+
+### Issue: Tag already exists
+**Solution**: Delete tag locally and remotely, create new one
+```bash
+git tag -d 4.8.0
+git push origin :refs/tags/4.8.0
+```
+
+### Issue: CHANGELOG.md conflicts
+**Solution**: Merge carefully, ensure all entries preserved
+
+## Best Practices
+
+1. **Release regularly**: Don't let changes pile up
+2. **Test thoroughly**: Releases are permanent
+3. **Document clearly**: CHANGELOG.md is crucial
+4. **Version correctly**: Follow semantic versioning
+
+## Permissions
+
+Only the project maintainer can:
+- Publish to Maven Central
+- Create GitHub Releases
+- Push release tags
+
+Contributors can:
+- Prepare release PRs
+- Update CHANGELOG.md
+- Test release candidates
+- Suggest version bumps
+
+---
+
+*Reliable releases build user trust.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,260 @@
+# Android Image Cropper - Claude AI Development Guide
+
+This document provides project-specific instructions for AI-assisted development on the Android Image Cropper library.
+
+## Project Overview
+
+**Android Image Cropper** optimized image cropping capabilities for Android applications.
+
+## Tech Stack
+
+- **Language**: Kotlin 2.0.0
+- **Build System**: Gradle 8.5.2 with Kotlin DSL
+- **Android**: minSdk 21, compileSdk 34, targetSdk 34
+- **Key Dependencies**:
+  - AndroidX (AppCompat, Core, Activity, ExifInterface)
+  - Kotlin Coroutines 1.8.1
+  - Material Components
+- **Testing**: JUnit, MockK, Robolectric, Paparazzi (snapshot testing)
+- **Code Quality**: ktlint 1.3.1, Dokka (documentation)
+
+## Module Structure
+
+```
+Android-Image-Cropper/
+├── cropper/           # Main library module (published artifact)
+│   └── src/
+│       ├── main/      # Library source code
+│       └── test/      # Unit tests
+├── sample/            # Sample app demonstrating usage
+│   └── src/main/      # Sample implementations
+├── .github/           # CI/CD workflows
+└── gradle/            # Build configuration
+```
+
+## Code Style & Conventions
+
+### Kotlin Style
+- **Code Style**: IntelliJ IDEA
+- **Indentation**: 2 spaces (no tabs)
+- **Continuation Indent**: 2 spaces
+- **Trailing Commas**: Allowed and encouraged
+- **Line Length**: No maximum (disabled)
+- **Linter**: ktlint with experimental features enabled
+- **Warnings**: All Kotlin warnings treated as errors
+
+### File Organization
+- Package structure: `com.canhub.cropper.*`
+- Internal APIs: Classes/methods not meant for public use should be marked `internal`
+- Public API: Keep minimal and well-documented
+- Deprecated APIs: Mark with `@Deprecated` and provide migration path
+
+### Code Quality Standards
+1. **No unused code**: Remove unused variables, functions, and imports
+2. **Type safety**: Leverage Kotlin's type system
+3. **Null safety**: Use Kotlin null-safety features appropriately
+4. **Coroutines**: Use for async operations (already in use for bitmap operations)
+5. **Resource management**: Always close resources properly (see BitmapUtils)
+
+## Build & Test Commands
+
+```bash
+# Build the project
+./gradlew build
+
+# Run all checks (linting, tests, etc.)
+./gradlew licensee ktlint testDebug build --stacktrace
+
+# Run unit tests
+./gradlew testDebug
+
+# Run ktlint
+./gradlew ktlint
+
+# Format code with ktlint
+./gradlew ktlintFormat
+
+# Run Paparazzi snapshot tests
+./gradlew verifyPaparazziDebug
+
+# Generate documentation
+./gradlew dokkaHtml
+```
+
+## Development Workflow
+
+### Making Changes
+
+1. **Branch Naming**: Use developer github name `canato/` prefix (e.g., `canato/fix-rotation-bug`)
+2. **Code Changes**:
+   - Make changes in `cropper/` module
+   - Update tests as needed
+   - Update sample app if adding new features
+3. **Before Committing**:
+   - Run `./gradlew ktlintFormat` to auto-format
+   - Run `./gradlew ktlint testDebug` to validate
+   - Ensure all tests pass
+4. **Commit Messages**: Follow existing style in CHANGELOG.md
+   - Start with category: "API:", "Fix:", "Security:", "Technical:", etc.
+   - Reference issue/PR numbers: `[#123]`
+
+### Testing Strategy
+
+1. **Unit Tests**: All business logic should have unit tests
+   - Location: `cropper/src/test/kotlin/`
+   - Use MockK for mocking
+   - Use Robolectric for Android framework dependencies
+2. **Snapshot Tests**: Use Paparazzi for UI component tests
+3. **Sample App**: Manual testing via `sample/` module
+4. **StrictMode**: Sample app has StrictMode enabled - no violations allowed
+
+### API Changes
+
+⚠️ **This is a published library** - API changes affect thousands of apps!
+
+#### Breaking Changes
+- **Avoid** breaking changes whenever possible
+- If unavoidable:
+  - Deprecate old API first
+  - Provide migration guide
+  - Increment major version
+  - Update CHANGELOG.md with migration notes
+
+#### Deprecation Process
+1. Mark as `@Deprecated` with message and replacement
+2. Keep deprecated code for at least one minor version
+3. Document in CHANGELOG.md
+4. Update README.md with migration guide
+5. Remove only in next major version
+
+#### Adding New APIs
+1. Add to public API only if necessary
+2. Document with KDoc
+3. Add usage example to sample app
+4. Update README.md if user-facing
+5. Consider making `internal` if not needed publicly
+
+## Release Process
+
+**DO NOT manually trigger releases** - handled by maintainer via GitHub Actions.
+
+1. **Snapshot Releases**: Auto-published from `main` branch to Maven Central
+2. **Release Versions**: 
+   - Update `VERSION_NAME` in `gradle.properties`
+   - Update `CHANGELOG.md`
+   - Tag release
+   - GitHub Actions publishes to Maven Central
+
+## Common Tasks
+
+### Adding a New Feature
+1. Read existing code in `cropper/src/main/kotlin/com/canhub/cropper/`
+2. Understand how `CropImageView` and related classes work
+3. Add feature with appropriate tests
+4. Update `CropImageOptions` if adding new configuration
+5. Add example to sample app
+6. Update CHANGELOG.md under "In development" section
+7. Update README.md if user-facing
+
+### Fixing a Bug
+1. Add a failing test that reproduces the bug
+2. Fix the bug
+3. Ensure test passes
+4. Run full test suite
+5. Update CHANGELOG.md with fix description and issue number
+
+### Updating Dependencies
+1. Dependencies managed in `gradle/libs.versions.toml`
+2. Test thoroughly after updates (especially Android/Kotlin versions)
+3. Check for API changes in dependencies
+4. Run full test suite
+5. Check sample app still works
+
+### Adding Translations
+1. Add strings to `cropper/src/main/res/values-{lang}/strings.xml`
+2. Copy structure from `values/strings.xml`
+3. Test in sample app with device language change
+4. Update CHANGELOG.md noting new language support
+
+## Important Files
+
+- **README.md**: User-facing documentation, API examples
+- **CHANGELOG.md**: All changes by version (REQUIRED for every change)
+- **gradle.properties**: Version, Maven coordinates, publishing config
+- **gradle/libs.versions.toml**: Dependency versions catalog
+- **build.gradle.kts**: Root build configuration
+- **cropper/build.gradle.kts**: Library module configuration
+- **lint.xml**: Android Lint configuration
+- **.editorconfig**: Code formatting rules
+- **.github/workflows/**: CI/CD pipelines
+
+## Key Classes to Understand
+
+1. **CropImageView**: Main public API - the custom view users add to layouts
+2. **CropImageOptions**: Configuration data class for cropping behavior
+3. **CropImageActivity**: (Deprecated) Activity-based cropping
+4. **CropImageContract**: Activity contract for cropping
+5. **CropOverlayView**: Internal - handles crop window UI
+6. **BitmapUtils**: Internal - image processing utilities
+7. **BitmapCroppingWorkerJob**: Internal - async cropping
+8. **BitmapLoadingWorkerJob**: Internal - async image loading
+
+## Security Considerations
+
+⚠️ **Security is critical** - this library handles user content and file URIs.
+
+1. **URI Validation**: Always validate URIs (see PR #680)
+2. **File Provider**: Proper file provider configuration required
+3. **Permissions**: Handle camera/storage permissions appropriately
+4. **Input Validation**: Validate all user inputs and image dimensions
+5. **Resource Limits**: Prevent OOM with large images (sampling is used)
+
+## Troubleshooting
+
+### Build Issues
+- Clean build: `./gradlew clean build`
+- Check Java version: Requires JDK 11+ (toolchain configured)
+- Check Android SDK: Requires SDK 34
+
+### Test Failures
+- Paparazzi failures: May need to record new snapshots
+- Robolectric failures: Check Android version compatibility
+
+### Lint Issues
+- Run `./gradlew ktlintFormat` to auto-fix
+- Check `.editorconfig` for disabled rules
+- See `lint.xml` for Android Lint configuration
+
+## AI Assistant Guidelines
+
+When working on this project:
+
+1. **Always read before editing**: Use Read tool on files before making changes
+2. **Respect code style**: Follow ktlint rules (2-space indent, trailing commas, etc.)
+3. **Update CHANGELOG.md**: Every change must be documented
+4. **Test your changes**: Add/update tests, run test suite
+5. **Check public API impact**: Breaking changes require deprecation cycle
+6. **Update documentation**: README.md for user-facing changes
+7. **Security first**: Validate inputs, handle errors, prevent security issues
+8. **Performance matters**: Large images are common - optimize for memory
+9. **Backward compatibility**: Support minSdk 21 (Android 5.0)
+10. **Sample app**: Update if adding features users should see
+
+### When Uncertain
+
+- **Architecture questions**: Check existing patterns in `CropImageView`
+- **API design**: Look at existing public APIs in the class
+- **Testing approach**: Check existing tests in `cropper/src/test/`
+- **Dependencies**: Check `gradle/libs.versions.toml` first
+- **Android compatibility**: Remember minSdk is 21
+
+## Helpful Resources
+
+- **Sample App**: Best reference for library usage
+- **CHANGELOG.md**: History of changes and API evolution
+- **GitHub Issues**: Known bugs and feature requests
+- **README.md**: User documentation and examples
+
+---
+
+*This document is maintained for AI-assisted development. Keep it updated as the project evolves.*


### PR DESCRIPTION
# Release Manager Agent

This PR adds a READ-ONLY release management agent.

## Release Types

- **Snapshot**: Automatic from main
- **Official**: Semantic versioning (major/minor/patch)
- **Hotfix**: Critical bug fixes
- **Pre-release**: Beta/RC versions

## Agent Configuration

- **Level**: 2 (Simple specialized task)
- **Model**: Sonnet
- **disallowedTools**: Write, Edit
- **Role**: Plans releases, maintainer executes

## Checklists

- Pre-release review (tests, docs, sample app)
- CHANGELOG.md finalization
- Version bumping
- Documentation updates
- Post-release tasks

## Depends On

- #685 (CLAUDE.md base)

---
*Wrote by Claude*